### PR TITLE
Implements error recovery for pipelines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ include(CTest)
 enable_testing()
 add_library(nativepg_test_utils STATIC test/test_utils/test_utils.cpp)
 target_include_directories(nativepg_test_utils PUBLIC test/test_utils/)
-target_link_libraries(nativepg_test_utils PUBLIC Boost::headers)
+target_link_libraries(nativepg_test_utils PUBLIC nativepg)
 
 function (add_unit_test TEST_DIR TEST_NAME)
     set(TARGET_NAME "nativepg_${TEST_NAME}")

--- a/include/nativepg/client_errc.hpp
+++ b/include/nativepg/client_errc.hpp
@@ -41,9 +41,9 @@ enum class client_errc : int
     // authentication in the current version
     mandatory_scram_extension_not_supported,
 
-    // Used in responses to indicate that we want more messages.
-    // TODO: this should really be in another category, at least, since it's not an error per se
-    needs_more,
+    // We received a smaller number of responses than required by the pipeline.
+    // This indicates that the response handler is not compatible with the request sent to the server.
+    not_enough_responses,
 
     // We got a message type that wasn't supposed to appear in the state we are
     unexpected_message,

--- a/include/nativepg/client_errc.hpp
+++ b/include/nativepg/client_errc.hpp
@@ -41,12 +41,17 @@ enum class client_errc : int
     // authentication in the current version
     mandatory_scram_extension_not_supported,
 
-    // We received a smaller number of responses than required by the pipeline.
-    // This indicates that the response handler is not compatible with the request sent to the server.
-    not_enough_responses,
-
-    // We got a message type that wasn't supposed to appear in the state we are
+    // We got a message type that wasn't supposed to appear in the state we are.
+    // This is a protocol violation.
     unexpected_message,
+
+    // We expected a number of responses different to the one we got.
+    // Review that your request and response types match. This is a user error.
+    incompatible_response_length,
+
+    // The response type is not compatible with the request that was sent to the server.
+    // Review that your request and response types match. This is a user error.
+    incompatible_response_type,
 
     // We got a NULL, but the C++ type where we're parsing into doesn't support NULLs
     unexpected_null,

--- a/include/nativepg/client_errc.hpp
+++ b/include/nativepg/client_errc.hpp
@@ -91,6 +91,9 @@ enum class client_errc : int
 
     // The server returned an error during the execution of a request
     exec_server_error,
+
+    // A pipeline step was skipped because of a previous error
+    step_skipped,
 };
 
 /// Creates an \ref error_code from a \ref client_errc.

--- a/include/nativepg/client_errc.hpp
+++ b/include/nativepg/client_errc.hpp
@@ -89,6 +89,12 @@ enum class client_errc : int
     // Requests must currently end with a sync. This restriction may be lifted in the future
     request_ends_without_sync,
 
+    // Request violates the restrictions when mixing the simple query and advanced query protocols.
+    // Currently, a request can mix both protocols only if all the advanced query protocol messages
+    // are separated from simple query messages by syncs (this is the default behavior unless you
+    // deactivated request autosync).
+    request_mixes_simple_advanced_protocols,
+
     // The server returned an error during the execution of a request
     exec_server_error,
 

--- a/include/nativepg/connection.hpp
+++ b/include/nativepg/connection.hpp
@@ -135,7 +135,7 @@ struct exec_op
                 impl.sock.async_read_some(res.read_buffer(), std::move(self));
                 break;
             case protocol::startup_fsm::result_type::done:
-                self.complete(extended_error{res.error(), impl.st.shared_diag});
+                self.complete(extended_error{res.error(), fsm_.final_diagnostics()});
                 break;
             default: BOOST_ASSERT(false);
         }

--- a/include/nativepg/connection.hpp
+++ b/include/nativepg/connection.hpp
@@ -134,9 +134,7 @@ struct exec_op
             case protocol::startup_fsm::result_type::read:
                 impl.sock.async_read_some(res.read_buffer(), std::move(self));
                 break;
-            case protocol::startup_fsm::result_type::done:
-                self.complete(extended_error{res.error(), fsm_.final_diagnostics()});
-                break;
+            case protocol::startup_fsm::result_type::done: self.complete(fsm_.get_result(res.error())); break;
             default: BOOST_ASSERT(false);
         }
     }

--- a/include/nativepg/extended_error.hpp
+++ b/include/nativepg/extended_error.hpp
@@ -39,7 +39,7 @@ public:
 struct extended_error
 {
     boost::system::error_code code;
-    diagnostics diag;
+    diagnostics diag{};
 
     friend bool operator==(const extended_error& lhs, const extended_error& rhs) noexcept = default;
 };

--- a/include/nativepg/protocol/detail/exec_fsm.hpp
+++ b/include/nativepg/protocol/detail/exec_fsm.hpp
@@ -39,7 +39,7 @@ public:
     }
 
 private:
-    bool is_writing_{true};
+    bool initial_{true};
     read_response_fsm read_fsm_;
 };
 

--- a/include/nativepg/protocol/detail/exec_fsm.hpp
+++ b/include/nativepg/protocol/detail/exec_fsm.hpp
@@ -17,6 +17,7 @@
 #include "nativepg/protocol/read_response_fsm.hpp"
 #include "nativepg/protocol/startup_fsm.hpp"
 #include "nativepg/request.hpp"
+#include "nativepg/response_handler.hpp"
 
 namespace nativepg::protocol::detail {
 
@@ -32,7 +33,10 @@ public:
 
     result resume(connection_state& st, boost::system::error_code ec, std::size_t bytes_transferred);
 
-    const diagnostics& final_diagnostics() const { return read_fsm_.final_diagnostics(); }
+    extended_error get_result(boost::system::error_code ec) const
+    {
+        return ec ? extended_error{ec, {}} : read_fsm_.get_handler().result();
+    }
 
 private:
     bool is_writing_{true};

--- a/include/nativepg/protocol/detail/exec_fsm.hpp
+++ b/include/nativepg/protocol/detail/exec_fsm.hpp
@@ -39,7 +39,14 @@ public:
     }
 
 private:
-    bool initial_{true};
+    enum class state_t
+    {
+        initial,
+        writing,
+        reading
+    };
+
+    state_t state_{state_t::initial};
     read_response_fsm read_fsm_;
 };
 

--- a/include/nativepg/protocol/detail/exec_fsm.hpp
+++ b/include/nativepg/protocol/detail/exec_fsm.hpp
@@ -12,6 +12,7 @@
 
 #include <cstddef>
 
+#include "nativepg/extended_error.hpp"
 #include "nativepg/protocol/connection_state.hpp"
 #include "nativepg/protocol/read_response_fsm.hpp"
 #include "nativepg/protocol/startup_fsm.hpp"
@@ -30,6 +31,8 @@ public:
     exec_fsm(const request& req, response_handler_ref handler) noexcept : read_fsm_(req, handler) {}
 
     result resume(connection_state& st, boost::system::error_code ec, std::size_t bytes_transferred);
+
+    const diagnostics& final_diagnostics() const { return read_fsm_.final_diagnostics(); }
 
 private:
     bool is_writing_{true};

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -59,13 +59,7 @@ private:
     std::size_t current_{};
     state_t state_{static_cast<state_t>(0)};
 
-    // TODO: move
-    result call_handler(const any_request_message& msg)
-    {
-        handler_.on_message(msg, current_);
-        return result(result_type::read);
-    }
-
+    inline void call_handler(const any_request_message& msg) { handler_.on_message(msg, current_); }
     result advance();
     result handle_bind(const any_backend_message&);
     result handle_close(const any_backend_message&);
@@ -75,8 +69,6 @@ private:
     result handle_sync(const any_backend_message&);
     result handle_query(const any_backend_message&);
     result handle_error(const error_response& err);
-
-    struct access;
 };
 
 }  // namespace detail

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -47,10 +47,9 @@ public:
     }
 
     const request& get_request() const { return *req_; }
+    response_handler_ref get_handler() const { return handler_; }
 
     result resume(const any_backend_message& msg);
-
-    const diagnostics& final_diagnostics() const { return stored_diag_; }
 
 private:
     const request* req_;
@@ -58,8 +57,6 @@ private:
     bool handler_finished_{};
     std::size_t remaining_syncs_{};
     bool initial_{true};
-    boost::system::error_code stored_ec_{};
-    diagnostics stored_diag_{};  // TODO: could we reuse this somehow?
 
     struct visitor;
 };
@@ -111,8 +108,7 @@ public:
     result resume(connection_state& st, boost::system::error_code io_error, std::size_t bytes_read);
 
     const request& get_request() const { return impl_.get_request(); }
-
-    const diagnostics& final_diagnostics() const { return impl_.final_diagnostics(); }
+    response_handler_ref get_handler() const { return impl_.get_handler(); }
 
 private:
     int resume_point_{0};

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -52,10 +52,12 @@ public:
     result resume(const any_backend_message& msg);
 
 private:
+    enum class state_t;
+
     const request* req_;
     response_handler_ref handler_;
     std::size_t current_{};
-    int resume_point_{0};
+    state_t state_{static_cast<state_t>(0)};
 
     // TODO: move
     result call_handler(const any_request_message& msg)
@@ -63,14 +65,6 @@ private:
         handler_.on_message(msg, current_);
         return result(result_type::read);
     }
-
-    enum resume_point
-    {
-        resume_msg_first,
-        resume_query_first,
-        resume_query_needs_ready,
-        resume_query_rows,
-    };
 
     result advance();
     result handle_bind(const any_backend_message&);

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -54,20 +54,13 @@ public:
 private:
     const request* req_;
     response_handler_ref handler_;
-    bool handler_finished_{};
     std::size_t current_{};
     int resume_point_{0};
 
     // TODO: move
     result call_handler(const any_request_message& msg)
     {
-        handler_status res = handler_.on_message(msg);
-
-        // If the handler is done, remember this fact
-        if (res == handler_status::done)
-            handler_finished_ = true;
-
-        // In any case, we need to keep reading until all the expected messages are received
+        handler_.on_message(msg, current_);
         return result(result_type::read);
     }
 

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -16,6 +16,7 @@
 #include "nativepg/extended_error.hpp"
 #include "nativepg/protocol/connection_state.hpp"
 #include "nativepg/protocol/messages.hpp"
+#include "nativepg/protocol/notice_error.hpp"
 #include "nativepg/request.hpp"
 #include "nativepg/response_handler.hpp"
 
@@ -67,10 +68,9 @@ private:
     enum resume_point
     {
         resume_initial = 0,
-        resume_skipping,
         resume_msg_first,
         resume_query_first,
-        resume_query_needs_sync,
+        resume_query_needs_ready,
         resume_query_rows,
     };
 
@@ -82,6 +82,7 @@ private:
     result handle_parse(const any_backend_message&);
     result handle_sync(const any_backend_message&);
     result handle_query(const any_backend_message&);
+    result handle_error(const error_response& err);
 
     struct access;
 };

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -58,7 +58,8 @@ private:
     bool handler_finished_{};
     std::size_t remaining_syncs_{};
     bool initial_{true};
-    diagnostics current_diag_{}, stored_diag_{};  // TODO: could we reuse this somehow?
+    boost::system::error_code stored_ec_{};
+    diagnostics stored_diag_{};  // TODO: could we reuse this somehow?
 
     struct visitor;
 };

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -48,7 +48,9 @@ public:
 
     const request& get_request() const { return *req_; }
 
-    result resume(diagnostics& diag, const any_backend_message& msg);
+    result resume(const any_backend_message& msg);
+
+    const diagnostics& final_diagnostics() const { return stored_diag_; }
 
 private:
     const request* req_;
@@ -56,6 +58,7 @@ private:
     bool handler_finished_{};
     std::size_t remaining_syncs_{};
     bool initial_{true};
+    diagnostics current_diag_{}, stored_diag_{};  // TODO: could we reuse this somehow?
 
     struct visitor;
 };
@@ -104,14 +107,11 @@ public:
 
     read_response_fsm(const request& req, response_handler_ref handler) noexcept : impl_(req, handler) {}
 
-    result resume(
-        connection_state& st,
-        diagnostics& diag,
-        boost::system::error_code io_error,
-        std::size_t bytes_read
-    );
+    result resume(connection_state& st, boost::system::error_code io_error, std::size_t bytes_read);
 
     const request& get_request() const { return impl_.get_request(); }
+
+    const diagnostics& final_diagnostics() const { return impl_.final_diagnostics(); }
 
 private:
     int resume_point_{0};

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -13,7 +13,6 @@
 
 #include <cstddef>
 
-#include "nativepg/extended_error.hpp"
 #include "nativepg/protocol/connection_state.hpp"
 #include "nativepg/protocol/messages.hpp"
 #include "nativepg/protocol/notice_error.hpp"

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -66,7 +66,6 @@ private:
 
     enum resume_point
     {
-        resume_initial = 0,
         resume_msg_first,
         resume_query_first,
         resume_query_needs_ready,
@@ -136,7 +135,6 @@ public:
     response_handler_ref get_handler() const { return impl_.get_handler(); }
 
 private:
-    int resume_point_{0};
     detail::read_response_fsm_impl impl_;
 };
 

--- a/include/nativepg/request.hpp
+++ b/include/nativepg/request.hpp
@@ -35,7 +35,7 @@
 namespace nativepg {
 
 namespace detail {
-enum class request_msg_type
+enum class request_message_type
 {
     bind,
     close,
@@ -67,7 +67,7 @@ struct statement
 class request
 {
     std::vector<unsigned char> buffer_;
-    std::vector<detail::request_msg_type> types_;
+    std::vector<detail::request_message_type> types_;
     bool autosync_;
 
     friend struct detail::request_access;
@@ -81,7 +81,7 @@ class request
     }
 
     template <class T>
-    request& add_advanced_impl(const T& value, detail::request_msg_type type)
+    request& add_advanced_impl(const T& value, detail::request_message_type type)
     {
         types_.reserve(types_.size() + 1u);  // strong guarantee
         check(protocol::serialize(value, buffer_));
@@ -272,40 +272,49 @@ public:
 
     request& add(const protocol::bind& value)
     {
-        return add_advanced_impl(value, detail::request_msg_type::bind);
+        return add_advanced_impl(value, detail::request_message_type::bind);
     }
 
     request& add(const protocol::close& value)
     {
-        return add_advanced_impl(value, detail::request_msg_type::close);
+        return add_advanced_impl(value, detail::request_message_type::close);
     }
 
     request& add(const protocol::describe& value)
     {
-        return add_advanced_impl(value, detail::request_msg_type::describe);
+        return add_advanced_impl(value, detail::request_message_type::describe);
     }
 
     request& add(const protocol::execute& value)
     {
-        return add_advanced_impl(value, detail::request_msg_type::execute);
+        return add_advanced_impl(value, detail::request_message_type::execute);
     }
 
-    request& add(protocol::flush value) { return add_advanced_impl(value, detail::request_msg_type::flush); }
+    request& add(protocol::flush value)
+    {
+        return add_advanced_impl(value, detail::request_message_type::flush);
+    }
 
     request& add(const protocol::parse_t& value)
     {
-        return add_advanced_impl(value, detail::request_msg_type::parse);
+        return add_advanced_impl(value, detail::request_message_type::parse);
     }
 
-    request& add(protocol::query value) { return add_advanced_impl(value, detail::request_msg_type::query); }
+    request& add(protocol::query value)
+    {
+        return add_advanced_impl(value, detail::request_message_type::query);
+    }
 
-    request& add(protocol::sync value) { return add_advanced_impl(value, detail::request_msg_type::sync); }
+    request& add(protocol::sync value)
+    {
+        return add_advanced_impl(value, detail::request_message_type::sync);
+    }
 };
 
 namespace detail {
 struct request_access
 {
-    static boost::span<const request_msg_type> messages(const request& r) { return r.types_; }
+    static boost::span<const request_message_type> messages(const request& r) { return r.types_; }
 };
 }  // namespace detail
 

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -237,6 +237,29 @@ class resultset_callback_t
 
         // TODO: this should be transmitted to the user somehow
         handler_status operator()(protocol::portal_suspended) const { return on_done(); }
+
+        // If any of the messages we expect was skipped due to a previous error,
+        // that's an error
+        handler_status operator()(bind_skipped) const
+        {
+            self.store_error(client_errc::step_skipped);
+            return handler_status::needs_more;
+        }
+        handler_status operator()(parse_skipped) const
+        {
+            self.store_error(client_errc::step_skipped);
+            return handler_status::needs_more;
+        }
+        handler_status operator()(describe_skipped) const
+        {
+            self.store_error(client_errc::step_skipped);
+            return handler_status::needs_more;
+        }
+        handler_status operator()(execute_skipped) const
+        {
+            self.store_error(client_errc::step_skipped);
+            return handler_status::done;
+        }
     };
 
 public:

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -61,6 +61,8 @@ boost::system::error_code compute_pos_map(
 
 inline constexpr std::size_t invalid_pos = static_cast<std::size_t>(-1);
 
+handler_setup_result resultset_setup(const request& req, std::size_t offset);
+
 }  // namespace detail
 
 // Handles a resultset (i.e. a row_description + data_rows + command_complete)
@@ -223,62 +225,9 @@ public:
     {
     }
 
-    // TODO: move to compiled
     handler_setup_result setup(const request& req, std::size_t offset)
     {
-        const auto msgs = req.messages().subspan(offset);
-        bool describe_found = false, execute_found = false;
-        auto it = msgs.begin();
-
-        // Skip any leading syncs
-        while (it != msgs.end() && (*it == request_message_type::sync || *it == request_message_type::flush))
-            ++it;
-
-        // The original message may be a query. In this case, it must be the only message
-        if (*it == request_message_type::query)
-        {
-            ++it;
-            return {static_cast<std::size_t>(it - msgs.begin())};
-        }
-
-        // Otherwise, it must be an extended query sequence:
-        //   optional parse
-        //   optional bind
-        //   exactly one describe portal
-        //   exactly one execute
-        // There may be flush messages, but no sync messages in between
-        //   (otherwise, error behavior becomes unreliable)
-        for (; it != msgs.end() && !execute_found; ++it)
-        {
-            switch (*it)
-            {
-                // Ignore parse, bind and flush messages
-                case request_message_type::flush:
-                case request_message_type::parse:
-                case request_message_type::bind: continue;
-                case request_message_type::describe:
-                    if (describe_found)
-                        return handler_setup_result(client_errc::incompatible_response_type);
-                    else
-                        describe_found = true;
-                    break;
-                case request_message_type::execute:
-                    if (!describe_found || execute_found)
-                        return handler_setup_result(client_errc::incompatible_response_type);
-                    else
-                        execute_found = true;
-                    break;
-                default: return handler_setup_result(client_errc::incompatible_response_type);
-            }
-        }
-
-        // Skip any further sync messages
-        while (it != msgs.end() && (*it == request_message_type::sync || *it == request_message_type::flush))
-            ++it;
-
-        // If we got the execute message, we're good
-        return execute_found ? handler_setup_result{static_cast<std::size_t>(it - msgs.begin())}
-                             : handler_setup_result{client_errc::incompatible_response_type};
+        return detail::resultset_setup(req, offset);
     }
 
     void on_message(const any_request_message& msg, std::size_t)

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -213,10 +213,7 @@ class resultset_callback_t
 
         // If any of the messages we expect was skipped due to a previous error,
         // that's an error
-        void operator()(bind_skipped) const { self.store_error(client_errc::step_skipped); }
-        void operator()(parse_skipped) const { self.store_error(client_errc::step_skipped); }
-        void operator()(describe_skipped) const { self.store_error(client_errc::step_skipped); }
-        void operator()(execute_skipped) const { self.store_error(client_errc::step_skipped); }
+        void operator()(message_skipped) const { self.store_error(client_errc::step_skipped); }
     };
 
 public:

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -170,8 +170,6 @@ class resultset_callback_t
             return handler_status::needs_more;
         }
 
-        handler_status operator()(protocol::no_data) const { return (*this)(protocol::row_description{}); }
-
         handler_status operator()(const protocol::data_row& msg) const
         {
             // State check

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -89,7 +89,7 @@ class resultset_callback_t
         template <class Msg>
         response_handler_result operator()(const Msg&) const
         {
-            return response_handler_result(client_errc::unexpected_message, true);
+            return response_handler_result(client_errc::incompatible_response_type, true);
         }
 
         // On error, fail the entire operation.
@@ -106,20 +106,20 @@ class resultset_callback_t
             // Only allowed before metadata
             return self.state_ == state_t::parsing_meta
                        ? response_handler_result::needs_more()
-                       : response_handler_result(client_errc::unexpected_message, true);
+                       : response_handler_result(client_errc::incompatible_response_type, true);
         }
         response_handler_result operator()(protocol::bind_complete) const
         {
             return self.state_ == state_t::parsing_meta
                        ? response_handler_result::needs_more()
-                       : response_handler_result(client_errc::unexpected_message, true);
+                       : response_handler_result(client_errc::incompatible_response_type, true);
         }
 
         response_handler_result operator()(const protocol::row_description& msg) const
         {
             // State check
             if (self.state_ != state_t::parsing_meta)
-                return response_handler_result(client_errc::unexpected_message, true);
+                return response_handler_result(client_errc::incompatible_response_type, true);
 
             // Compute the row => C++ map
             auto ec = detail::compute_pos_map(msg, detail::row_name_table_v<T>, self.pos_map_);
@@ -155,7 +155,7 @@ class resultset_callback_t
         {
             // State check
             if (self.state_ != state_t::parsing_data)
-                return response_handler_result(client_errc::unexpected_message, true);
+                return response_handler_result(client_errc::incompatible_response_type, true);
 
             // TODO: check that data_row has the appropriate size
 
@@ -191,7 +191,7 @@ class resultset_callback_t
         {
             // State check
             if (self.state_ != state_t::parsing_data)
-                return response_handler_result(client_errc::unexpected_message, true);
+                return response_handler_result(client_errc::incompatible_response_type, true);
 
             // Done
             self.state_ = state_t::done;
@@ -203,7 +203,7 @@ class resultset_callback_t
         {
             // State check
             if (self.state_ != state_t::parsing_data)
-                return response_handler_result(client_errc::unexpected_message, true);
+                return response_handler_result(client_errc::incompatible_response_type, true);
 
             // Done
             self.state_ = state_t::done;
@@ -284,7 +284,7 @@ public:
     {
         // If we're done and another message is received, that's an error
         if (current_ >= N)
-            return response_handler_result(client_errc::unexpected_message, true);
+            return response_handler_result(client_errc::incompatible_response_length, true);
 
         // Call the handler
         response_handler_result res = vtable_[current_](msg, diag);

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -123,6 +123,7 @@ class resultset_callback_t
         void operator()(const protocol::row_description& msg) const
         {
             // State check
+            // TODO: this can trigger on multi-queries
             BOOST_ASSERT(self.state_ == state_t::parsing_meta);
 
             // We now expect the rows and the CommandComplete

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -46,7 +46,6 @@ using any_request_message = boost::variant2::variant<
     protocol::data_row,
     protocol::parameter_description,
     protocol::row_description,
-    protocol::no_data,
     protocol::empty_query_response,
     protocol::portal_suspended,
     protocol::error_response,

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -30,15 +30,10 @@ namespace nativepg {
 
 class diagnostics;
 
-// These are not actual messages, but a placeholder type to signal
+// Not an actual message, but a placeholder type to signal
 // that the corresponding message was skipped due to a previous error
-// TODO: make this a single type
 // clang-format off
-struct parse_skipped {};
-struct bind_skipped {};
-struct close_skipped {};
-struct execute_skipped {};
-struct describe_skipped {};
+struct message_skipped {};
 // clang-format on
 
 // TODO: maybe make this a class
@@ -53,11 +48,7 @@ using any_request_message = boost::variant2::variant<
     protocol::portal_suspended,
     protocol::error_response,
     protocol::parse_complete,
-    parse_skipped,
-    bind_skipped,
-    close_skipped,
-    execute_skipped,
-    describe_skipped>;
+    message_skipped>;
 
 // TODO: improve API
 struct handler_setup_result

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -32,9 +32,9 @@ class diagnostics;
 
 // Not an actual message, but a placeholder type to signal
 // that the corresponding message was skipped due to a previous error
-// clang-format off
-struct message_skipped {};
-// clang-format on
+struct message_skipped
+{
+};
 
 // TODO: maybe make this a class
 using any_request_message = boost::variant2::variant<
@@ -67,7 +67,6 @@ concept response_handler = requires(
     T& handler,
     const request& req,
     const any_request_message& msg,
-    diagnostics& diag,
     std::size_t offset
 ) {
     { handler.setup(req, offset) } -> std::convertible_to<handler_setup_result>;

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -8,10 +8,12 @@
 #ifndef NATIVEPG_RESPONSE_HANDLER_HPP
 #define NATIVEPG_RESPONSE_HANDLER_HPP
 
-#include <boost/compat/function_ref.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/variant2/variant.hpp>
 
+#include <concepts>
+
+#include "nativepg/extended_error.hpp"
 #include "nativepg/protocol/bind.hpp"
 #include "nativepg/protocol/close.hpp"
 #include "nativepg/protocol/command_complete.hpp"
@@ -40,31 +42,49 @@ using any_request_message = boost::variant2::variant<
     protocol::error_response,
     protocol::parse_complete>;
 
-class response_handler_result
-{
-    boost::system::error_code ec_;
-    bool done_{true};
-
-public:
-    // TODO: make this bool more typed
-    response_handler_result() noexcept = default;
-    response_handler_result(boost::system::error_code ec, bool done) noexcept : ec_(ec), done_(done) {}
-
-    static response_handler_result needs_more(boost::system::error_code ec = {}) { return {ec, false}; }
-    static response_handler_result done(boost::system::error_code ec = {}) { return {ec, true}; }
-
-    boost::system::error_code error() const { return ec_; }
-    bool is_done() const { return done_; }
-
-    friend bool operator==(const response_handler_result&, const response_handler_result&) = default;
-};
-
-using response_handler_ref = boost::compat::function_ref<
-    response_handler_result(const any_request_message&, diagnostics&)>;
-
 template <class T>
 concept response_handler = requires(T& handler, const any_request_message& msg, diagnostics& diag) {
-    { handler(msg, diag) } -> std::convertible_to<response_handler_result>;
+    { handler.on_message(msg) };
+    { handler.result() } -> std::convertible_to<extended_error>;
+};
+
+enum class handler_status
+{
+    needs_more,
+    done,
+};
+
+// Type-erased reference to a response handler
+class response_handler_ref
+{
+    using on_message_fn = handler_status (*)(void*, const any_request_message&);
+    using result_fn = extended_error (*)(const void*);
+
+    void* obj_;
+    on_message_fn on_message_;
+    result_fn result_;
+
+    template <class T>
+    static handler_status do_on_message(void* obj, const any_request_message& msg)
+    {
+        return static_cast<T*>(obj)->on_message(msg);
+    }
+
+    template <class T>
+    static extended_error do_result(const void* obj)
+    {
+        return static_cast<const T*>(obj)->result();
+    }
+
+public:
+    template <response_handler T>
+        requires(!std::same_as<T, response_handler_ref>)
+    response_handler_ref(T& obj) noexcept : obj_(&obj), on_message_(&do_on_message<T>), result_(&do_result<T>)
+    {
+    }
+
+    handler_status on_message(const any_request_message& req) { return on_message_(obj_, req); }
+    extended_error result() const { return result_(obj_); }
 };
 
 }  // namespace nativepg

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -51,7 +51,7 @@ public:
     response_handler_result(boost::system::error_code ec, bool done) noexcept : ec_(ec), done_(done) {}
 
     static response_handler_result needs_more(boost::system::error_code ec = {}) { return {ec, false}; }
-    static response_handler_result done(boost::system::error_code ec) { return {ec, true}; }
+    static response_handler_result done(boost::system::error_code ec = {}) { return {ec, true}; }
 
     boost::system::error_code error() const { return ec_; }
     bool is_done() const { return done_; }

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -50,10 +50,11 @@ public:
     response_handler_result() noexcept = default;
     response_handler_result(boost::system::error_code ec, bool done) noexcept : ec_(ec), done_(done) {}
 
-    static response_handler_result needs_more() { return {{}, false}; }
+    static response_handler_result needs_more(boost::system::error_code ec = {}) { return {ec, false}; }
+    static response_handler_result done(boost::system::error_code ec) { return {ec, true}; }
 
     boost::system::error_code error() const { return ec_; }
-    bool done() const { return done_; }
+    bool is_done() const { return done_; }
 };
 
 using response_handler_ref = boost::compat::function_ref<

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -58,6 +58,8 @@ struct handler_setup_result
 
     handler_setup_result(boost::system::error_code ec) noexcept : ec(ec) {}
     handler_setup_result(std::size_t offset) noexcept : offset(offset) {}
+
+    friend bool operator==(const handler_setup_result&, const handler_setup_result&) = default;
 };
 
 template <class T>

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -55,6 +55,8 @@ public:
 
     boost::system::error_code error() const { return ec_; }
     bool is_done() const { return done_; }
+
+    friend bool operator==(const response_handler_result&, const response_handler_result&) = default;
 };
 
 using response_handler_ref = boost::compat::function_ref<

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -28,6 +28,16 @@ namespace nativepg {
 
 class diagnostics;
 
+// These are not actual messages, but a placeholder type to signal
+// that the corresponding message was skipped due to a previous error
+// clang-format off
+struct parse_skipped {};
+struct bind_skipped {};
+struct close_skipped {};
+struct execute_skipped {};
+struct describe_skipped {};
+// clang-format on
+
 // TODO: maybe make this a class
 using any_request_message = boost::variant2::variant<
     protocol::bind_complete,
@@ -40,7 +50,12 @@ using any_request_message = boost::variant2::variant<
     protocol::empty_query_response,
     protocol::portal_suspended,
     protocol::error_response,
-    protocol::parse_complete>;
+    protocol::parse_complete,
+    parse_skipped,
+    bind_skipped,
+    close_skipped,
+    execute_skipped,
+    describe_skipped>;
 
 template <class T>
 concept response_handler = requires(T& handler, const any_request_message& msg, diagnostics& diag) {

--- a/src/fsm.cpp
+++ b/src/fsm.cpp
@@ -371,7 +371,7 @@ struct read_response_fsm_impl::visitor
             if (self.stored_ec_)
                 return self.stored_ec_;
             else if (!self.handler_finished_)
-                return error_code(client_errc::needs_more);
+                return error_code(client_errc::not_enough_responses);
             else
                 return error_code();
         }

--- a/src/fsm.cpp
+++ b/src/fsm.cpp
@@ -49,7 +49,7 @@ using detail::read_response_fsm_impl;
 using detail::startup_fsm_impl;
 using nativepg::client_errc;
 using nativepg::detail::request_access;
-using nativepg::detail::request_msg_type;
+using nativepg::detail::request_message_type;
 
 read_message_fsm::result read_message_fsm::resume(std::span<const unsigned char> data)
 {

--- a/src/fsm.cpp
+++ b/src/fsm.cpp
@@ -343,7 +343,7 @@ struct read_response_fsm_impl::visitor
         auto res = self.handler_(msg, diag);
 
         // If the handler is done, remember this fact
-        if (res.done())
+        if (res.is_done())
             self.handler_finished_ = true;
 
         // If the handler reports an error, keep it as the overall operation result

--- a/src/fsm.cpp
+++ b/src/fsm.cpp
@@ -336,11 +336,10 @@ std::size_t count_syncs(std::span<const request_msg_type> msgs)
 struct read_response_fsm_impl::visitor
 {
     read_response_fsm_impl& self;
-    diagnostics& diag;
 
     result call_handler(const any_request_message& msg) const
     {
-        auto res = self.handler_(msg, diag);
+        auto res = self.handler_(msg, self.stored_diag_);
         if (res)
         {
             return res == client_errc::needs_more ? result(result_type::read) : res;
@@ -392,10 +391,7 @@ struct read_response_fsm_impl::visitor
     }
 };
 
-read_response_fsm_impl::result read_response_fsm_impl::resume(
-    diagnostics& diag,
-    const any_backend_message& msg
-)
+read_response_fsm_impl::result read_response_fsm_impl::resume(const any_backend_message& msg)
 {
     // Initial checks
     if (initial_)
@@ -419,12 +415,11 @@ read_response_fsm_impl::result read_response_fsm_impl::resume(
         return result_type::read;
     }
 
-    return boost::variant2::visit(visitor{*this, diag}, msg);
+    return boost::variant2::visit(visitor{*this}, msg);
 }
 
 read_response_fsm::result read_response_fsm::resume(
     connection_state& st,
-    diagnostics& diag,
     boost::system::error_code io_error,
     std::size_t bytes_read
 )
@@ -442,7 +437,7 @@ read_response_fsm::result read_response_fsm::resume(
         while (true)
         {
             // Call the FSM
-            startup_res = impl_.resume(diag, msg);
+            startup_res = impl_.resume(msg);
             if (startup_res.type == read_response_fsm_impl::result_type::done)
             {
                 // We're finished
@@ -495,7 +490,7 @@ exec_fsm::result exec_fsm::resume(
         return ec;
 
     // TODO: this is passing a wrong bytes_transferred value the 1st time
-    auto act = read_fsm_.resume(st, st.shared_diag, ec, bytes_transferred);
+    auto act = read_fsm_.resume(st, ec, bytes_transferred);
     switch (act.type())
     {
         case read_response_fsm::result_type::read: return result::read(act.read_buffer());

--- a/src/fsm.cpp
+++ b/src/fsm.cpp
@@ -329,10 +329,10 @@ startup_fsm::result startup_fsm::resume(
 
 enum class read_response_fsm_impl::state_t
 {
-    resume_msg_first = 0,
-    resume_query_first,
-    resume_query_needs_ready,
-    resume_query_rows,
+    msg_first = 0,
+    query_first,
+    query_needs_ready,
+    query_rows,
 };
 
 read_response_fsm_impl::result read_response_fsm_impl::handle_error(const error_response& err)
@@ -340,7 +340,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_error(const error_
     // Call the handler with the error
     call_handler(err);
     ++current_;
-    state_ = state_t::resume_msg_first;
+    state_ = state_t::msg_first;
 
     // Skip subsequent messages until a sync is found
     // We should always find one because we check that this is the case
@@ -370,7 +370,7 @@ read_response_fsm_impl::result read_response_fsm_impl::advance()
 read_response_fsm_impl::result read_response_fsm_impl::handle_bind(const any_backend_message& msg)
 {
     // bind: either (bind_complete, error_response, bind_skipped)
-    BOOST_ASSERT(state_ == state_t::resume_msg_first);
+    BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
         // An error finishes this message and makes the server skip everything until
@@ -392,7 +392,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_bind(const any_bac
 read_response_fsm_impl::result read_response_fsm_impl::handle_close(const any_backend_message& msg)
 {
     // close: either (close_complete, error_response, close_skipped)
-    BOOST_ASSERT(state_ == state_t::resume_msg_first);
+    BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
         // An error finishes this message and makes the server skip everything until
@@ -421,7 +421,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_describe(const any
     //   parameter_description, then either (row_description, no_data)
     //   error_response
     //   describe_skipped
-    BOOST_ASSERT(state_ == state_t::resume_msg_first);
+    BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
         // An error finishes this message and makes the server skip everything until
@@ -453,7 +453,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_execute(const any_
     //   either:
     //      any number of data_row, then either (command_complete,
     //      empty_query_response, portal_suspended, error_response) execute_skipped
-    BOOST_ASSERT(state_ == state_t::resume_msg_first);
+    BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
         // An error finishes this message and makes the server skip everything
@@ -493,7 +493,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_execute(const any_
 read_response_fsm_impl::result read_response_fsm_impl::handle_parse(const any_backend_message& msg)
 {
     // parse: either (parse_complete, error_response, parse_skipped)
-    BOOST_ASSERT(state_ == state_t::resume_msg_first);
+    BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
         // An error finishes this message and makes the server skip everything until
@@ -516,7 +516,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_sync(const any_bac
 {
     // sync always returns ReadyForQuery. Getting an error here is a protocol error,
     // as we don't know whether the connection is healthy or not
-    BOOST_ASSERT(state_ == state_t::resume_msg_first);
+    BOOST_ASSERT(state_ == state_t::msg_first);
     if (!holds_alternative<ready_for_query>(msg))
         return error_code(client_errc::unexpected_message);
     return advance();
@@ -534,42 +534,42 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_query(const any_ba
     // or message_skipped (synthesized by us)
     switch (state_)
     {
-        case state_t::resume_msg_first:
-        case state_t::resume_query_first:
+        case state_t::msg_first:
+        case state_t::query_first:
         {
             if (const auto* err = get_if<error_response>(&msg))
             {
                 // An error should always be followed by ReadyForQuery
-                state_ = state_t::resume_query_needs_ready;
+                state_ = state_t::query_needs_ready;
                 return call_handler(*err);
             }
             else if (const auto* desc = get_if<row_description>(&msg))
             {
                 // Row descriptions are optional, and can only appear at the beginning of
                 // a resultset, but should always precede rows
-                state_ = state_t::resume_query_rows;
+                state_ = state_t::query_rows;
                 return call_handler(*desc);
             }
             else if (const auto* complete = get_if<command_complete>(&msg))
             {
                 // Query might return command_complete directly, without NoData.
                 // Synthesize a fake row_description to help handlers
-                state_ = state_t::resume_query_first;
+                state_ = state_t::query_first;
                 call_handler(row_description{});
                 return call_handler(*complete);
             }
             else if (const auto* eq = get_if<empty_query_response>(&msg))
             {
                 // Only allowed as the first and only message. Signals that there was no query to begin with
-                if (state_ != state_t::resume_msg_first)
+                if (state_ != state_t::msg_first)
                     return error_code(client_errc::unexpected_message);
-                state_ = state_t::resume_query_needs_ready;
+                state_ = state_t::query_needs_ready;
                 return call_handler(*eq);
             }
-            else if (holds_alternative<ready_for_query>(msg) && state_ == state_t::resume_query_first)
+            else if (holds_alternative<ready_for_query>(msg) && state_ == state_t::query_first)
             {
                 // Not allowed as the only response to a query
-                state_ = state_t::resume_msg_first;
+                state_ = state_t::msg_first;
                 return advance();
             }
             else
@@ -577,12 +577,12 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_query(const any_ba
                 return error_code(client_errc::unexpected_message);
             }
         }
-        case state_t::resume_query_rows:
+        case state_t::query_rows:
         {
             if (const auto* err = get_if<error_response>(&msg))
             {
                 // An error should always be followed by ReadyForQuery
-                state_ = state_t::resume_query_needs_ready;
+                state_ = state_t::query_needs_ready;
                 return call_handler(*err);
             }
             else if (const auto* row = get_if<data_row>(&msg))
@@ -593,7 +593,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_query(const any_ba
             else if (const auto* complete = get_if<command_complete>(&msg))
             {
                 // This resultset is done
-                state_ = state_t::resume_query_first;
+                state_ = state_t::query_first;
                 return call_handler(*complete);
             }
             else
@@ -601,13 +601,13 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_query(const any_ba
                 return error_code(client_errc::unexpected_message);
             }
         }
-        case state_t::resume_query_needs_ready:
+        case state_t::query_needs_ready:
         {
             // Only a sync is allowed here. Not even an error
             if (holds_alternative<ready_for_query>(msg))
             {
                 // We're done with the current message
-                state_ = state_t::resume_msg_first;
+                state_ = state_t::msg_first;
                 return advance();
             }
             else

--- a/src/fsm.cpp
+++ b/src/fsm.cpp
@@ -371,7 +371,7 @@ struct read_response_fsm_impl::visitor
             if (self.stored_ec_)
                 return self.stored_ec_;
             else if (!self.handler_finished_)
-                return error_code(client_errc::not_enough_responses);
+                return error_code(client_errc::incompatible_response_length);
             else
                 return error_code();
         }

--- a/src/fsm.cpp
+++ b/src/fsm.cpp
@@ -369,7 +369,7 @@ read_response_fsm_impl::result read_response_fsm_impl::advance()
 
 read_response_fsm_impl::result read_response_fsm_impl::handle_bind(const any_backend_message& msg)
 {
-    // bind: either (bind_complete, error_response, bind_skipped)
+    // bind: either (bind_complete, error_response)
     BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
@@ -391,7 +391,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_bind(const any_bac
 
 read_response_fsm_impl::result read_response_fsm_impl::handle_close(const any_backend_message& msg)
 {
-    // close: either (close_complete, error_response, close_skipped)
+    // close: either (close_complete, error_response)
     BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
@@ -416,11 +416,10 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_close(const any_ba
 read_response_fsm_impl::result read_response_fsm_impl::handle_describe(const any_backend_message& msg)
 {
     // describe (portal)
-    //   either: row_description, no_data, error_response, describe_skipped
+    //   either: row_description, no_data, error_response
     // describe (statement) TODO: support this. Either
     //   parameter_description, then either (row_description, no_data)
     //   error_response
-    //   describe_skipped
     BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
@@ -449,10 +448,9 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_describe(const any
 
 read_response_fsm_impl::result read_response_fsm_impl::handle_execute(const any_backend_message& msg)
 {
-    // execute
-    //   either:
-    //      any number of data_row, then either (command_complete,
-    //      empty_query_response, portal_suspended, error_response) execute_skipped
+    // execute: either:
+    //   any number of data_row, then either (command_complete, portal_suspended, error_response)
+    //   empty_query_response
     BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
@@ -493,7 +491,7 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_execute(const any_
 
 read_response_fsm_impl::result read_response_fsm_impl::handle_parse(const any_backend_message& msg)
 {
-    // parse: either (parse_complete, error_response, parse_skipped)
+    // parse: either (parse_complete, error_response)
     BOOST_ASSERT(state_ == state_t::msg_first);
     if (const auto* err = get_if<error_response>(&msg))
     {
@@ -529,10 +527,9 @@ read_response_fsm_impl::result read_response_fsm_impl::handle_query(const any_ba
     //    at least one
     //        optional row_description (we synthesize one of not present)
     //        any number of data_row
-    //        finalizer: command_complete, empty_query_response, error_response
+    //        finalizer: command_complete, error_response
     //    ready_for_query
     // or empty_query_response
-    // or message_skipped (synthesized by us)
     switch (state_)
     {
         case state_t::msg_first:

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -173,7 +173,7 @@ handler_setup_result detail::resultset_setup(const request& req, std::size_t off
     if (*it == request_message_type::query)
     {
         ++it;
-        return {static_cast<std::size_t>(it - msgs.begin())};
+        return {static_cast<std::size_t>(it - req.messages().begin())};
     }
 
     // Otherwise, it must be an extended query sequence:
@@ -212,6 +212,6 @@ handler_setup_result detail::resultset_setup(const request& req, std::size_t off
         ++it;
 
     // If we got the execute message, we're good
-    return execute_found ? handler_setup_result{static_cast<std::size_t>(it - msgs.begin())}
+    return execute_found ? handler_setup_result{static_cast<std::size_t>(it - req.messages().begin())}
                          : handler_setup_result{client_errc::incompatible_response_type};
 }

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -158,3 +158,60 @@ boost::system::error_code detail::compute_pos_map(
 
     return {};
 }
+
+handler_setup_result detail::resultset_setup(const request& req, std::size_t offset)
+{
+    const auto msgs = req.messages().subspan(offset);
+    bool describe_found = false, execute_found = false;
+    auto it = msgs.begin();
+
+    // Skip any leading syncs
+    while (it != msgs.end() && (*it == request_message_type::sync || *it == request_message_type::flush))
+        ++it;
+
+    // The original message may be a query. In this case, it must be the only message
+    if (*it == request_message_type::query)
+    {
+        ++it;
+        return {static_cast<std::size_t>(it - msgs.begin())};
+    }
+
+    // Otherwise, it must be an extended query sequence:
+    //   optional parse
+    //   optional bind
+    //   exactly one describe portal
+    //   exactly one execute
+    // There may be flush messages, but no sync messages in between
+    //   (otherwise, error behavior becomes unreliable)
+    for (; it != msgs.end() && !execute_found; ++it)
+    {
+        switch (*it)
+        {
+            // Ignore parse, bind and flush messages
+            case request_message_type::flush:
+            case request_message_type::parse:
+            case request_message_type::bind: continue;
+            case request_message_type::describe:
+                if (describe_found)
+                    return handler_setup_result(client_errc::incompatible_response_type);
+                else
+                    describe_found = true;
+                break;
+            case request_message_type::execute:
+                if (!describe_found || execute_found)
+                    return handler_setup_result(client_errc::incompatible_response_type);
+                else
+                    execute_found = true;
+                break;
+            default: return handler_setup_result(client_errc::incompatible_response_type);
+        }
+    }
+
+    // Skip any further sync messages
+    while (it != msgs.end() && (*it == request_message_type::sync || *it == request_message_type::flush))
+        ++it;
+
+    // If we got the execute message, we're good
+    return execute_found ? handler_setup_result{static_cast<std::size_t>(it - msgs.begin())}
+                         : handler_setup_result{client_errc::incompatible_response_type};
+}

--- a/test/test_utils/printing.hpp
+++ b/test/test_utils/printing.hpp
@@ -13,8 +13,10 @@
 namespace nativepg {
 
 struct extended_error;
-
 std::ostream& operator<<(std::ostream&, const extended_error&);
+
+struct handler_setup_result;
+std::ostream& operator<<(std::ostream& os, const handler_setup_result&);
 
 }  // namespace nativepg
 

--- a/test/test_utils/printing.hpp
+++ b/test/test_utils/printing.hpp
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef NATIVEPG_TEST_PRINTING_HPP
+#define NATIVEPG_TEST_PRINTING_HPP
+
+#include <iosfwd>
+
+namespace nativepg {
+
+struct extended_error;
+
+std::ostream& operator<<(std::ostream&, const extended_error&);
+
+}  // namespace nativepg
+
+#endif

--- a/test/test_utils/response_msg_type.hpp
+++ b/test/test_utils/response_msg_type.hpp
@@ -75,6 +75,18 @@ inline response_msg_type to_type(const any_request_message& msg)
     return boost::variant2::visit(visitor{}, msg);
 }
 
+struct on_msg_args
+{
+    response_msg_type type;
+    std::size_t offset;
+
+    friend bool operator==(const on_msg_args&, const on_msg_args&) = default;
+    friend std::ostream& operator<<(std::ostream& os, const on_msg_args& v)
+    {
+        return os << "{ " << to_string(v.type) << ", " << v.offset << " }";
+    }
+};
+
 }  // namespace nativepg::test
 
 #endif

--- a/test/test_utils/response_msg_type.hpp
+++ b/test/test_utils/response_msg_type.hpp
@@ -25,11 +25,11 @@ enum class response_msg_type
     data_row,
     parameter_description,
     row_description,
-    no_data,
     empty_query_response,
     portal_suspended,
     error_response,
     parse_complete,
+    message_skipped,
 };
 
 inline const char* to_string(response_msg_type value)
@@ -42,11 +42,11 @@ inline const char* to_string(response_msg_type value)
         case response_msg_type::data_row: return "data_row";
         case response_msg_type::parameter_description: return "parameter_description";
         case response_msg_type::row_description: return "row_description";
-        case response_msg_type::no_data: return "no_data";
         case response_msg_type::empty_query_response: return "empty_query_response";
         case response_msg_type::portal_suspended: return "portal_suspended";
         case response_msg_type::error_response: return "error_response";
         case response_msg_type::parse_complete: return "parse_complete";
+        case response_msg_type::message_skipped: return "message_skipped";
         default: return "<unknown response_msg_type>";
     }
 }
@@ -64,11 +64,11 @@ inline response_msg_type to_type(const any_request_message& msg)
         response_msg_type operator()(const protocol::data_row&) const { return response_msg_type::data_row;}
         response_msg_type operator()(const protocol::parameter_description&) const { return response_msg_type::parameter_description;}
         response_msg_type operator()(const protocol::row_description&) const { return response_msg_type::row_description;}
-        response_msg_type operator()(const protocol::no_data&) const { return response_msg_type::no_data;}
         response_msg_type operator()(const protocol::empty_query_response&) const { return response_msg_type::empty_query_response;}
         response_msg_type operator()(const protocol::portal_suspended&) const { return response_msg_type::portal_suspended;}
         response_msg_type operator()(const protocol::error_response&) const { return response_msg_type::error_response;}
         response_msg_type operator()(const protocol::parse_complete&) const { return response_msg_type::parse_complete;}
+        response_msg_type operator()(const message_skipped&) const { return response_msg_type::message_skipped;}
         // clang-format on
     };
 

--- a/test/test_utils/test_utils.cpp
+++ b/test/test_utils/test_utils.cpp
@@ -12,6 +12,8 @@
 #include <string_view>
 #include <vector>
 
+#include "nativepg/extended_error.hpp"
+#include "printing.hpp"
 #include "test_utils.hpp"
 
 namespace {
@@ -42,4 +44,10 @@ void nativepg::test::print_context()
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << "Failure occurred in the following context:\n";
     for (auto it = context.rbegin(); it != context.rend(); ++it)
         BOOST_LIGHTWEIGHT_TEST_OSTREAM << "  " << it->loc << ": " << it->message << '\n';
+}
+
+// --- Printing ---
+std::ostream& nativepg::operator<<(std::ostream& os, const extended_error& err)
+{
+    return os << "{ .code=" << err.code << ", .diag=" << err.diag.message() << "}";
 }

--- a/test/test_utils/test_utils.cpp
+++ b/test/test_utils/test_utils.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "nativepg/extended_error.hpp"
+#include "nativepg/response_handler.hpp"
 #include "printing.hpp"
 #include "test_utils.hpp"
 
@@ -50,4 +51,12 @@ void nativepg::test::print_context()
 std::ostream& nativepg::operator<<(std::ostream& os, const extended_error& err)
 {
     return os << "{ .code=" << err.code << ", .diag=" << err.diag.message() << "}";
+}
+
+std::ostream& nativepg::operator<<(std::ostream& os, const handler_setup_result& value)
+{
+    if (value.ec)
+        return os << "{ .ec=" << value.ec << " }";
+    else
+        return os << "{ .offset=" << value.offset << " }";
 }

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -75,26 +75,26 @@ void test_impl_simple_query()
     std::vector<response_msg_type> msgs;
     auto handler = [&msgs](const any_request_message& msg, diagnostics&) {
         msgs.push_back(to_type(msg));
-        return error_code();
+        return response_handler_result::done();
     };
     diagnostics diag;
 
     read_response_fsm_impl fsm{req, handler};
 
     // Initiate
-    auto act = fsm.resume(diag, {});
+    auto act = fsm.resume({});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
 
     // Server messages
-    act = fsm.resume(diag, protocol::row_description{});
+    act = fsm.resume(protocol::row_description{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::data_row{});
+    act = fsm.resume(protocol::data_row{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::data_row{});
+    act = fsm.resume(protocol::data_row{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::command_complete{});
+    act = fsm.resume(protocol::command_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, error_code());
 
     // Check handler messages
@@ -115,28 +115,28 @@ void test_impl_extended_query()
     std::vector<response_msg_type> msgs;
     auto handler = [&msgs](const any_request_message& msg, diagnostics&) {
         msgs.push_back(to_type(msg));
-        return error_code();
+        return response_handler_result::done();
     };
     diagnostics diag;
 
     read_response_fsm_impl fsm{req, handler};
 
     // Initiate
-    auto act = fsm.resume(diag, {});
+    auto act = fsm.resume({});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
 
     // Server messages
-    act = fsm.resume(diag, protocol::bind_complete{});
+    act = fsm.resume(protocol::bind_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::parse_complete{});
+    act = fsm.resume(protocol::parse_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::row_description{});
+    act = fsm.resume(protocol::row_description{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::data_row{});
+    act = fsm.resume(protocol::data_row{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::portal_suspended{});
+    act = fsm.resume(protocol::portal_suspended{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, error_code());
 
     // Check handler messages
@@ -159,7 +159,7 @@ void test_impl_all_msg_types()
     std::vector<response_msg_type> msgs;
     auto handler = [&msgs](const any_request_message& msg, diagnostics&) {
         msgs.push_back(to_type(msg));
-        return error_code();
+        return response_handler_result::done();
     };
 
     diagnostics diag;
@@ -167,33 +167,33 @@ void test_impl_all_msg_types()
     read_response_fsm_impl fsm{req, handler};
 
     // Initiate
-    auto act = fsm.resume(diag, {});
+    auto act = fsm.resume({});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
 
     // Server messages
-    act = fsm.resume(diag, protocol::bind_complete{});
+    act = fsm.resume(protocol::bind_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::close_complete{});
+    act = fsm.resume(protocol::close_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::command_complete{});
+    act = fsm.resume(protocol::command_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::data_row{});
+    act = fsm.resume(protocol::data_row{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::parameter_description{});
+    act = fsm.resume(protocol::parameter_description{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::row_description{});
+    act = fsm.resume(protocol::row_description{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::no_data{});
+    act = fsm.resume(protocol::no_data{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::empty_query_response{});
+    act = fsm.resume(protocol::empty_query_response{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::portal_suspended{});
+    act = fsm.resume(protocol::portal_suspended{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::error_response{});
+    act = fsm.resume(protocol::error_response{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::parse_complete{});
+    act = fsm.resume(protocol::parse_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, error_code());
 
     // Check handler messages
@@ -222,7 +222,7 @@ void test_impl_async()
     std::vector<response_msg_type> msgs;
     auto handler = [&msgs](const any_request_message& msg, diagnostics&) {
         msgs.push_back(to_type(msg));
-        return error_code();
+        return response_handler_result::done();
     };
 
     diagnostics diag;
@@ -230,19 +230,19 @@ void test_impl_async()
     read_response_fsm_impl fsm{req, handler};
 
     // Initiate
-    auto act = fsm.resume(diag, {});
+    auto act = fsm.resume({});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
 
     // Server messages
-    act = fsm.resume(diag, protocol::bind_complete{});
+    act = fsm.resume(protocol::bind_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::notice_response{});
+    act = fsm.resume(protocol::notice_response{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::notification_response{});
+    act = fsm.resume(protocol::notification_response{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::parameter_status{});
+    act = fsm.resume(protocol::parameter_status{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, error_code());
 
     // Check handler messages
@@ -262,32 +262,32 @@ void test_impl_several_syncs()
     std::vector<response_msg_type> msgs;
     auto handler = [&msgs](const any_request_message& msg, diagnostics&) {
         msgs.push_back(to_type(msg));
-        return error_code();
+        return response_handler_result::done();
     };
     diagnostics diag;
 
     read_response_fsm_impl fsm{req, handler};
 
     // Initiate
-    auto act = fsm.resume(diag, {});
+    auto act = fsm.resume({});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
 
     // Server messages
-    act = fsm.resume(diag, protocol::close_complete{});
+    act = fsm.resume(protocol::close_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::row_description{});
+    act = fsm.resume(protocol::row_description{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::data_row{});
+    act = fsm.resume(protocol::data_row{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::command_complete{});
+    act = fsm.resume(protocol::command_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::parameter_description{});
+    act = fsm.resume(protocol::parameter_description{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, error_code());
 
     // Check handler messages
@@ -310,22 +310,22 @@ void test_impl_needs_more_success()
     std::vector<response_msg_type> msgs;
     auto handler = [&msgs](const any_request_message& msg, diagnostics&) {
         msgs.push_back(to_type(msg));
-        return msgs.size() >= 2u ? error_code() : error_code(client_errc::needs_more);
+        return response_handler_result({}, msgs.size() >= 2u);
     };
     diagnostics diag;
 
     read_response_fsm_impl fsm{req, handler};
 
     // Initiate
-    auto act = fsm.resume(diag, {});
+    auto act = fsm.resume({});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
 
     // Server messages
-    act = fsm.resume(diag, protocol::no_data{});
+    act = fsm.resume(protocol::no_data{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::command_complete{});
+    act = fsm.resume(protocol::command_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
+    act = fsm.resume(protocol::ready_for_query{});
     BOOST_TEST_EQ(act, error_code());
 
     // Check handler messages
@@ -344,23 +344,23 @@ void test_impl_needs_more_error()
     std::vector<response_msg_type> msgs;
     auto handler = [&msgs](const any_request_message& msg, diagnostics&) {
         msgs.push_back(to_type(msg));
-        return error_code(client_errc::needs_more);
+        return response_handler_result::needs_more();
     };
     diagnostics diag;
 
     read_response_fsm_impl fsm{req, handler};
 
     // Initiate
-    auto act = fsm.resume(diag, {});
+    auto act = fsm.resume({});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
 
     // Server messages
-    act = fsm.resume(diag, protocol::no_data{});
+    act = fsm.resume(protocol::no_data{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::command_complete{});
+    act = fsm.resume(protocol::command_complete{});
     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(diag, protocol::ready_for_query{});
-    BOOST_TEST_EQ(act, error_code(client_errc::needs_more));
+    act = fsm.resume(protocol::ready_for_query{});
+    BOOST_TEST_EQ(act, error_code(client_errc::incompatible_response_length));
 }
 
 // TODO: test errors

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -7,18 +7,15 @@
 
 #include <boost/assert/source_location.hpp>
 #include <boost/core/lightweight_test.hpp>
-#include <boost/system/detail/error_code.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/variant2/variant.hpp>
 
 #include <cstddef>
 #include <initializer_list>
 #include <iostream>
-#include <iterator>
 #include <ostream>
 #include <vector>
 
-#include "nativepg/client_errc.hpp"
 #include "nativepg/extended_error.hpp"
 #include "nativepg/protocol/async.hpp"
 #include "nativepg/protocol/bind.hpp"

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -104,7 +104,6 @@ void test_impl_simple_query()
     read_response_fsm_impl fsm{req, handler};
 
     // Run the FSM
-    BOOST_TEST_EQ(fsm.resume({}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::row_description{}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::data_row{}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::data_row{}), result_type::read);
@@ -129,7 +128,6 @@ void test_impl_extended_query()
     read_response_fsm_impl fsm{req, handler};
 
     // Run the FSM
-    BOOST_TEST_EQ(fsm.resume({}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::parse_complete{}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::bind_complete{}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::row_description{}), result_type::read);
@@ -156,7 +154,6 @@ void test_impl_parse()
     read_response_fsm_impl fsm{req, handler};
 
     // Ru the FSM
-    BOOST_TEST_EQ(fsm.resume({}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::parse_complete{}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::ready_for_query{}), error_code());
 
@@ -174,11 +171,7 @@ void test_impl_async()
     mock_handler handler;
     read_response_fsm_impl fsm{req, handler};
 
-    // Initiate
-    auto act = fsm.resume({});
-    BOOST_TEST_EQ(act, result_type::read);
-
-    // Server messages
+    // Run the FSM
     BOOST_TEST_EQ(fsm.resume(protocol::parse_complete{}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::notice_response{}), result_type::read);
     BOOST_TEST_EQ(fsm.resume(protocol::notification_response{}), result_type::read);

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -69,18 +69,6 @@ std::ostream& operator<<(std::ostream& os, const read_response_fsm_impl::result&
 namespace {
 
 // A handler that just stores its arguments
-struct on_msg_args
-{
-    response_msg_type type;
-    std::size_t offset;
-
-    friend bool operator==(const on_msg_args&, const on_msg_args&) = default;
-    friend std::ostream& operator<<(std::ostream& os, const on_msg_args& v)
-    {
-        return os << "{ " << to_string(v.type) << ", " << v.offset << " }";
-    }
-};
-
 struct mock_handler
 {
     std::vector<on_msg_args> msgs;

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -37,15 +37,16 @@ using namespace nativepg;
 using namespace nativepg::test;
 using boost::system::error_code;
 using protocol::detail::read_response_fsm_impl;
+using result_type = read_response_fsm_impl::result_type;
 
 // Operators
-static const char* to_string(read_response_fsm_impl::result_type t)
+static const char* to_string(result_type t)
 {
     switch (t)
     {
-        case read_response_fsm_impl::result_type::done: return "done";
-        case read_response_fsm_impl::result_type::read: return "read";
-        default: return "<unknown read_response_fsm_impl::result_type>";
+        case result_type::done: return "done";
+        case result_type::read: return "read";
+        default: return "<unknown result_type>";
     }
 }
 
@@ -59,7 +60,7 @@ bool operator==(const read_response_fsm_impl::result& lhs, const read_response_f
 std::ostream& operator<<(std::ostream& os, const read_response_fsm_impl::result& value)
 {
     os << "read_response_fsm_impl::result{ .type=" << to_string(value.type);
-    if (value.type == read_response_fsm_impl::result_type::done)
+    if (value.type == result_type::done)
         os << ", .ec=" << value.ec;
     return os << " }";
 }
@@ -92,19 +93,14 @@ void test_impl_simple_query()
 
     // Initiate
     auto act = fsm.resume({});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+    BOOST_TEST_EQ(act, result_type::read);
 
     // Server messages
-    act = fsm.resume(protocol::row_description{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::data_row{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::data_row{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::command_complete{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::ready_for_query{});
-    BOOST_TEST_EQ(act, error_code());
+    BOOST_TEST_EQ(fsm.resume(protocol::row_description{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::data_row{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::data_row{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
     const on_msg_args expected_msgs[] = {
@@ -131,21 +127,15 @@ void test_impl_extended_query()
 
     // Initiate
     auto act = fsm.resume({});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+    BOOST_TEST_EQ(act, result_type::read);
 
     // Server messages
-    act = fsm.resume(protocol::parse_complete{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::bind_complete{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::row_description{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::data_row{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::command_complete{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::ready_for_query{});
-    BOOST_TEST_EQ(act, error_code());
+    BOOST_TEST_EQ(fsm.resume(protocol::parse_complete{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::bind_complete{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::row_description{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::data_row{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
     const on_msg_args expected_msgs[] = {
@@ -173,19 +163,14 @@ void test_impl_async()
 
     // Initiate
     auto act = fsm.resume({});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+    BOOST_TEST_EQ(act, result_type::read);
 
     // Server messages
-    act = fsm.resume(protocol::parse_complete{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::notice_response{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::notification_response{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::parameter_status{});
-    BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
-    act = fsm.resume(protocol::ready_for_query{});
-    BOOST_TEST_EQ(act, error_code());
+    BOOST_TEST_EQ(fsm.resume(protocol::parse_complete{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::notice_response{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::notification_response{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::parameter_status{}), result_type::read);
+    BOOST_TEST_EQ(fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
     const on_msg_args expected_msgs[] = {
@@ -218,31 +203,31 @@ void test_impl_async()
 
 //     // Initiate
 //     auto act = fsm.resume({});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 
 //     // Server messages
 //     act = fsm.resume(protocol::bind_complete{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::close_complete{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::command_complete{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::data_row{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::parameter_description{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::row_description{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::no_data{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::empty_query_response{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::portal_suspended{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::error_response{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::parse_complete{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::ready_for_query{});
 //     BOOST_TEST_EQ(act, error_code());
 
@@ -281,23 +266,23 @@ void test_impl_async()
 
 //     // Initiate
 //     auto act = fsm.resume({});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 
 //     // Server messages
 //     act = fsm.resume(protocol::close_complete{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::ready_for_query{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::row_description{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::data_row{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::command_complete{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::ready_for_query{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::parameter_description{});
-//     BOOST_TEST_EQ(act, read_response_fsm_impl::result_type::read);
+//     BOOST_TEST_EQ(act, result_type::read);
 //     act = fsm.resume(protocol::ready_for_query{});
 //     BOOST_TEST_EQ(act, error_code());
 

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -42,6 +42,8 @@ using boost::system::error_code;
 using protocol::detail::read_response_fsm_impl;
 using result_type = read_response_fsm_impl::result_type;
 
+// TODO: rename this file when we implement the external API tests
+
 // Operators
 static const char* to_string(result_type t)
 {
@@ -103,7 +105,7 @@ struct fixture
 };
 
 // --- Responses to a simple query ---
-void test_impl_simple_query()
+void test_simple_query()
 {
     fixture fix;
     fix.req.add_simple_query("SELECT 1");
@@ -126,7 +128,7 @@ void test_impl_simple_query()
 
 // Queries that don't return data don't include a row_description.
 // We synthesize an empty row_description for simplicity
-void test_impl_simple_query_no_data()
+void test_simple_query_no_data()
 {
     fixture fix;
     fix.req.add_simple_query("SELECT 1");
@@ -143,7 +145,7 @@ void test_impl_simple_query_no_data()
 }
 
 // Response to an extended query
-void test_impl_extended_query()
+void test_extended_query()
 {
     fixture fix;
     fix.req.add_query("SELECT 1", {});
@@ -167,7 +169,7 @@ void test_impl_extended_query()
 }
 
 // Response to an individual parse
-void test_impl_parse()
+void test_parse()
 {
     fixture fix;
     fix.req.add_prepare("SELECT 1", "mystmt");
@@ -183,7 +185,7 @@ void test_impl_parse()
 }
 
 // Async messages (notices, notifications, parameter descriptions) are ignored
-void test_impl_async()
+void test_async()
 {
     fixture fix;
     fix.req.add_prepare("SELECT 1", "mystmt");
@@ -258,12 +260,12 @@ void test_impl_async()
 
 int main()
 {
-    test_impl_simple_query();
-    test_impl_simple_query_no_data();
+    test_simple_query();
+    test_simple_query_no_data();
 
-    test_impl_extended_query();
-    test_impl_parse();
-    test_impl_async();
+    test_extended_query();
+    test_parse();
+    test_async();
     // test_impl_several_syncs();
 
     return boost::report_errors();

--- a/test/unit/test_request.cpp
+++ b/test/unit/test_request.cpp
@@ -21,23 +21,23 @@
 #include "test_utils.hpp"
 
 using namespace nativepg;
-using detail::request_msg_type;
+using detail::request_message_type;
 
 namespace nativepg::detail {
 
-std::ostream& operator<<(std::ostream& os, request_msg_type type)
+std::ostream& operator<<(std::ostream& os, request_message_type type)
 {
     switch (type)
     {
-    case request_msg_type::bind: return os << "bind";
-    case request_msg_type::close: return os << "close";
-    case request_msg_type::describe: return os << "describe";
-    case request_msg_type::execute: return os << "execute";
-    case request_msg_type::flush: return os << "flush";
-    case request_msg_type::parse: return os << "parse";
-    case request_msg_type::query: return os << "query";
-    case request_msg_type::sync: return os << "sync";
-    default: return os << "<unknown request_msg_type>";
+        case request_message_type::bind: return os << "bind";
+        case request_message_type::close: return os << "close";
+        case request_message_type::describe: return os << "describe";
+        case request_message_type::execute: return os << "execute";
+        case request_message_type::flush: return os << "flush";
+        case request_message_type::parse: return os << "parse";
+        case request_message_type::query: return os << "query";
+        case request_message_type::sync: return os << "sync";
+        default: return os << "<unknown request_msg_type>";
     }
 }
 

--- a/test/unit/test_request.cpp
+++ b/test/unit/test_request.cpp
@@ -21,9 +21,8 @@
 #include "test_utils.hpp"
 
 using namespace nativepg;
-using detail::request_message_type;
 
-namespace nativepg::detail {
+namespace nativepg {
 
 std::ostream& operator<<(std::ostream& os, request_message_type type)
 {
@@ -37,11 +36,11 @@ std::ostream& operator<<(std::ostream& os, request_message_type type)
         case request_message_type::parse: return os << "parse";
         case request_message_type::query: return os << "query";
         case request_message_type::sync: return os << "sync";
-        default: return os << "<unknown request_msg_type>";
+        default: return os << "<unknown request_message_type>";
     }
 }
 
-}  // namespace nativepg::detail
+}  // namespace nativepg
 
 namespace {
 
@@ -57,12 +56,12 @@ void check_payload(
 
 void check_messages(
     const request& req,
-    std::initializer_list<request_msg_type> expected,
+    std::initializer_list<request_message_type> expected,
     std::source_location loc = std::source_location::current()
 )
 {
     test::context_frame frame{loc};
-    NATIVEPG_TEST_CONT_EQ(detail::request_access::messages(req), expected);
+    NATIVEPG_TEST_CONT_EQ(req.messages(), expected);
 }
 
 // Simple query
@@ -75,7 +74,7 @@ void test_simple_query()
         req,
         {0x51, 0x00, 0x00, 0x00, 0x0e, 0x73, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x20, 0x31, 0x3b, 0x00}
     );
-    check_messages(req, {request_msg_type::query});
+    check_messages(req, {request_message_type::query});
 }
 
 // Query with parameters
@@ -111,11 +110,11 @@ void test_query()
     check_messages(
         req,
         {
-            request_msg_type::parse,
-            request_msg_type::bind,
-            request_msg_type::describe,
-            request_msg_type::execute,
-            request_msg_type::sync,
+            request_message_type::parse,
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
         }
     );
 }
@@ -151,11 +150,11 @@ void test_query_text()
     check_messages(
         req,
         {
-            request_msg_type::parse,
-            request_msg_type::bind,
-            request_msg_type::describe,
-            request_msg_type::execute,
-            request_msg_type::sync,
+            request_message_type::parse,
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
         }
     );
 }
@@ -181,7 +180,7 @@ void test_prepare_untyped()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::parse, request_msg_type::sync});
+    check_messages(req, {request_message_type::parse, request_message_type::sync});
 }
 
 void test_prepare_typed()
@@ -203,7 +202,7 @@ void test_prepare_typed()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::parse, request_msg_type::sync});
+    check_messages(req, {request_message_type::parse, request_message_type::sync});
 }
 
 // Execute
@@ -234,10 +233,10 @@ void test_execute_untyped()
     check_messages(
         req,
         {
-            request_msg_type::bind,
-            request_msg_type::describe,
-            request_msg_type::execute,
-            request_msg_type::sync,
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
         }
     );
 }
@@ -270,10 +269,10 @@ void test_execute_typed()
     check_messages(
         req,
         {
-            request_msg_type::bind,
-            request_msg_type::describe,
-            request_msg_type::execute,
-            request_msg_type::sync,
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
         }
     );
 }
@@ -311,10 +310,10 @@ void test_execute_typed_optional_args()
     check_messages(
         req,
         {
-            request_msg_type::bind,
-            request_msg_type::describe,
-            request_msg_type::execute,
-            request_msg_type::sync,
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
         }
     );
 }
@@ -335,7 +334,7 @@ void test_describe_statement()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::describe, request_msg_type::sync});
+    check_messages(req, {request_message_type::describe, request_message_type::sync});
 }
 
 void test_describe_portal()
@@ -353,7 +352,7 @@ void test_describe_portal()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::describe, request_msg_type::sync});
+    check_messages(req, {request_message_type::describe, request_message_type::sync});
 }
 
 // Close
@@ -372,7 +371,7 @@ void test_close_statement()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::close, request_msg_type::sync});
+    check_messages(req, {request_message_type::close, request_message_type::sync});
 }
 
 void test_close_portal()
@@ -390,7 +389,7 @@ void test_close_portal()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::close, request_msg_type::sync});
+    check_messages(req, {request_message_type::close, request_message_type::sync});
 }
 
 // Low-level
@@ -409,7 +408,7 @@ void test_bind_untyped()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::bind});
+    check_messages(req, {request_message_type::bind});
 }
 
 void test_bind_typed()
@@ -428,7 +427,7 @@ void test_bind_typed()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::bind});
+    check_messages(req, {request_message_type::bind});
 }
 
 // TODO: add with individual protocol messages
@@ -460,7 +459,10 @@ void test_prepare_batch()
     });
     // clang-format on
 
-    check_messages(req, {request_msg_type::parse, request_msg_type::parse, request_msg_type::sync});
+    check_messages(
+        req,
+        {request_message_type::parse, request_message_type::parse, request_message_type::sync}
+    );
 }
 
 void test_execute_batch()
@@ -501,13 +503,13 @@ void test_execute_batch()
     check_messages(
         req,
         {
-            request_msg_type::bind,
-            request_msg_type::describe,
-            request_msg_type::execute,
-            request_msg_type::bind,
-            request_msg_type::describe,
-            request_msg_type::execute,
-            request_msg_type::sync,
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
         }
     );
 }

--- a/test/unit/test_response.cpp
+++ b/test/unit/test_response.cpp
@@ -56,16 +56,16 @@ void test_success_two_handlers()
     diagnostics diag;
 
     // The 1st handler needs 2 messages, the 2nd one just one
-    auto ec = res(protocol::row_description{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::needs_more());
-    ec = res(protocol::data_row{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::needs_more());
-    ec = res(protocol::row_description{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::done({}));  // done
+    auto r = res(protocol::row_description{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::needs_more());
+    r = res(protocol::data_row{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::needs_more());
+    r = res(protocol::row_description{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::done({}));  // done
 
     // Passing another message is an error
-    ec = res(protocol::data_row{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::done(client_errc::incompatible_response_length));
+    r = res(protocol::data_row{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::done(client_errc::incompatible_response_length));
 
     // Check messages
     std::array expected1{response_msg_type::row_description, response_msg_type::data_row};
@@ -99,14 +99,14 @@ void test_errors()
     diagnostics diag;
 
     // h1 needs 2 messages, h2 needs 1, h3 needs 1
-    auto ec = res(protocol::row_description{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::needs_more(client_errc::exec_server_error));
-    ec = res(protocol::data_row{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::needs_more(client_errc::exec_server_error));
-    ec = res(protocol::parse_complete{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::needs_more({}));
-    ec = res(protocol::bind_complete{}, diag);
-    BOOST_TEST_EQ(ec, response_handler_result::done(client_errc::incompatible_field_type));
+    auto r = res(protocol::row_description{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::needs_more(client_errc::exec_server_error));
+    r = res(protocol::data_row{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::needs_more(client_errc::exec_server_error));
+    r = res(protocol::parse_complete{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::needs_more({}));
+    r = res(protocol::bind_complete{}, diag);
+    BOOST_TEST_EQ(r, response_handler_result::done(client_errc::incompatible_field_type));
 
     // Check messages
     std::array expected1{response_msg_type::row_description, response_msg_type::data_row};

--- a/test/unit/test_resultset_callback.cpp
+++ b/test/unit/test_resultset_callback.cpp
@@ -383,6 +383,7 @@ void test_error_incompatible_field_type()
 // TODO: queries with no data
 // TODO: properly test all types and what they support
 // TODO: all error conditions when parsing
+// TODO: test the setup() function
 
 }  // namespace
 

--- a/test/unit/test_resultset_callback.cpp
+++ b/test/unit/test_resultset_callback.cpp
@@ -356,6 +356,11 @@ void test_error_incompatible_field_type()
         cb(descrs, diag),
         response_handler_result::needs_more(client_errc::incompatible_field_type)
     );
+    BOOST_TEST_EQ(
+        cb(owning_data_row({"42", "perico"}), diag),
+        response_handler_result::needs_more(client_errc::step_skipped)
+    );
+    BOOST_TEST_EQ(cb(protocol::command_complete{}, diag), response_handler_result::done());
 }
 
 // TODO: parsing errors

--- a/test/unit/test_resultset_callback.cpp
+++ b/test/unit/test_resultset_callback.cpp
@@ -328,7 +328,15 @@ void test_error_field_not_present()
 
     // Messages
     BOOST_TEST_EQ(cb(descrs, diag), response_handler_result::needs_more(client_errc::field_not_found));
-    // TODO
+    BOOST_TEST_EQ(
+        cb(owning_data_row({"42", "perico"}), diag),
+        response_handler_result::needs_more(client_errc::step_skipped)
+    );
+    BOOST_TEST_EQ(
+        cb(owning_data_row({"50", "pepe"}), diag),
+        response_handler_result::needs_more(client_errc::step_skipped)
+    );
+    BOOST_TEST_EQ(cb(protocol::command_complete{}, diag), response_handler_result::done());
 }
 
 // If a field has an incompatible type, that's an error

--- a/test/unit/test_resultset_callback.cpp
+++ b/test/unit/test_resultset_callback.cpp
@@ -37,19 +37,6 @@ using boost::system::error_code;
 using protocol::format_code;
 using namespace std::string_view_literals;
 
-// Printing
-namespace nativepg {
-
-std::ostream& operator<<(std::ostream& os, handler_setup_result r)
-{
-    if (r.ec)
-        return os << "{ .ec=" << r.ec << " }";
-    else
-        return os << "{ .offset=" << r.offset << " }";
-}
-
-}  // namespace nativepg
-
 namespace {
 
 struct owning_row_description


### PR DESCRIPTION
Changes the handler interface to allow validation of compatibility with requests
Makes request_message_type public
Implements a robust algorithm to find when the response to a pipeline has been completely read
An individual error now leaves the connection in a usable state