### PR TITLE
Adds support for rvalue response handlers

### DIFF
--- a/example/co_connection.cpp
+++ b/example/co_connection.cpp
@@ -10,11 +10,14 @@
 #include <boost/corosio/io_context.hpp>
 #include <boost/describe/class.hpp>
 
+#include <concepts>
 #include <iostream>
+#include <type_traits>
 
 #include "nativepg/co_connection.hpp"
 #include "nativepg/extended_error.hpp"
 #include "nativepg/response.hpp"
+#include "nativepg/response_handler.hpp"
 
 using namespace nativepg;
 namespace capy = boost::capy;
@@ -67,7 +70,7 @@ static capy::task<> co_main()
     std::vector<myrow> vec;
     response res{check_execute(), into(vec)};
 
-    auto [ec2] = co_await conn.exec(req, res, &diag);
+    auto [ec2] = co_await conn.exec(req, &res, &diag);
     print_err("Operation result", ec2, diag);
     print_err("Q1 result", std::get<0>(res.handlers()).result());
     print_err("Q2 result", std::get<1>(res.handlers()).result());

--- a/example/co_connection.cpp
+++ b/example/co_connection.cpp
@@ -10,14 +10,11 @@
 #include <boost/corosio/io_context.hpp>
 #include <boost/describe/class.hpp>
 
-#include <concepts>
 #include <iostream>
-#include <type_traits>
 
 #include "nativepg/co_connection.hpp"
 #include "nativepg/extended_error.hpp"
 #include "nativepg/response.hpp"
-#include "nativepg/response_handler.hpp"
 
 using namespace nativepg;
 namespace capy = boost::capy;

--- a/example/co_connection_pool.cpp
+++ b/example/co_connection_pool.cpp
@@ -88,9 +88,8 @@ static capy::io_task<std::string> get_employee_details(co_connection_pool& pool,
     req.add_query("SELECT first_name, last_name FROM employee WHERE id = $1", {employee_id});
 
     std::vector<employee> rows;
-    response res{into(rows)};
 
-    auto [ec_exec] = co_await pconn->exec(req, res);
+    auto [ec_exec] = co_await pconn->exec(req, into(rows));
     if (ec_exec)
         co_return {ec_exec, {}};
 

--- a/example/co_multiplexed_connection.cpp
+++ b/example/co_multiplexed_connection.cpp
@@ -46,19 +46,16 @@ static capy::io_task<> run_request(co_multiplexed_connection& conn)
 {
     // Compose our request
     request req;
-    req.add_query("SELECT * FROM myt' WHERE f1 <> $1", {"abc"});
-    req.add_query("SELECT * FROM myt WHERE f1 <> 'abc'", {});
+    req.add_query("SELECT * FROM myt WHERE f1 <> $1", {"abc"});
+    req.add_query("SELECT * FROM myt WHERE f1 = 'abc'", {});
 
     // Structures to parse the response into
     std::vector<myrow> vec1, vec2;
-    response res{into(vec1), into(vec2)};
 
     // Execute it
     diagnostics diag;
-    auto [ec2] = co_await conn.exec(req, res, &diag);
+    auto [ec2] = co_await conn.exec(req, response{into(vec1), into(vec2)}, &diag);
     print_err("Operation result", ec2, diag);
-    print_err("Q1 result", std::get<0>(res.handlers()).result());
-    print_err("Q2 result", std::get<1>(res.handlers()).result());
 
     for (const auto& r : vec1)
         std::cout << "Got row (1): " << r.f1 << ", " << r.f3 << std::endl;

--- a/example/co_multiplexed_connection.cpp
+++ b/example/co_multiplexed_connection.cpp
@@ -37,11 +37,6 @@ static void print_err(const char* prefix, std::error_code err, const diagnostics
     std::cout << '\n';
 }
 
-static void print_err(const char* prefix, const extended_error& err)
-{
-    print_err(prefix, err.code, err.diag);
-}
-
 static capy::io_task<> run_request(co_multiplexed_connection& conn)
 {
     // Compose our request

--- a/example/copy_out.cpp
+++ b/example/copy_out.cpp
@@ -57,7 +57,7 @@ static capy::task<> co_main()
 
     // Setup the request for exec_some
     // Important: req and the handler must be kept alive until we finish executing
-    conn.setup_request(req, check_response);
+    conn.setup_request(req, &check_response);
 
     bool done = false;
     while (!done)

--- a/example/datetime.cpp
+++ b/example/datetime.cpp
@@ -14,14 +14,14 @@
 #include <boost/asio/this_coro.hpp>
 #include <boost/describe/class.hpp>
 
-#include <chrono>
 #include <cstdint>
 #include <exception>
-#include <format>
 #include <iomanip>
 #include <iostream>
 #include <string_view>
 #include <vector>
+#include <chrono>
+#include <format>
 
 #include "nativepg/connection.hpp"
 #include "nativepg/extended_error.hpp"
@@ -33,14 +33,14 @@ using namespace nativepg;
 
 struct date_row
 {
-    // std::chrono::sys_days d;
+    //std::chrono::sys_days d;
     types::pg_date d;
 };
 BOOST_DESCRIBE_STRUCT(date_row, (), (d))
 
 struct time_row
 {
-    // std::chrono::microseconds t;
+    //std::chrono::microseconds t;
     types::pg_time t;
 };
 BOOST_DESCRIBE_STRUCT(time_row, (), (t))
@@ -69,6 +69,7 @@ struct interval_row
 };
 BOOST_DESCRIBE_STRUCT(interval_row, (), (iv))
 
+
 // DATE to std::chrono::days
 static asio::awaitable<void> date_text_example(connection& conn)
 {
@@ -83,7 +84,7 @@ static asio::awaitable<void> date_text_example(connection& conn)
     std::vector<date_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -91,11 +92,9 @@ static asio::awaitable<void> date_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "DATE TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message()
-                  << " (in " << duration << ")" << std::endl;
+        std::cerr << "DATE TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "DATE TEXT select result: " << std::format("{0:%F}", select_vec[0].d) << " (in "
-                  << duration << ")" << std::endl;
+        std::cout << "DATE TEXT select result: " << std::format("{0:%F}", select_vec[0].d) << " (in " << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> date_binary_example(connection& conn)
@@ -105,20 +104,14 @@ static asio::awaitable<void> date_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::date as d", {"date_bintest"})
-        .add_execute(
-            "date_bintest",
-            {"1977-06-21"},
-            request::param_format::text,
-            protocol::format_code::binary,
-            1
-        );
+    req.add_prepare("SELECT $1::text::date as d", {"date_bintest"} )
+        .add_execute("date_bintest", {"1977-06-21"}, request::param_format::text, protocol::format_code::binary, 1);
 
     // Structures to parse the response into
     std::vector<date_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -126,11 +119,9 @@ static asio::awaitable<void> date_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "DATE BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
-                  << duration << ")" << std::endl;
+        std::cerr << "DATE BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "DATE BINARY select result: " << std::format("{0}", select_vec[0].d) << " (in "
-                  << duration << ")" << std::endl;
+        std::cout << "DATE BINARY select result: " << std::format("{0}", select_vec[0].d) << " (in " << duration << ")" << std::endl;
 }
 
 // TIME to std::chrono::microseconds
@@ -147,7 +138,7 @@ static asio::awaitable<void> time_text_example(connection& conn)
     std::vector<time_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -155,11 +146,9 @@ static asio::awaitable<void> time_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIME TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message()
-                  << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIME TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIME TEXT select result: " << std::format("{0:%T}", select_vec[0].t) << " (in "
-                  << duration << ")" << std::endl;
+        std::cout << "TIME TEXT select result: " << std::format("{0:%T}", select_vec[0].t) << " (in " << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> time_binary_example(connection& conn)
@@ -169,20 +158,14 @@ static asio::awaitable<void> time_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::time as t", {"bintest"})
-        .add_execute(
-            "bintest",
-            {"12:34:23.43535"},
-            request::param_format::text,
-            protocol::format_code::binary,
-            1
-        );
+    req.add_prepare("SELECT $1::text::time as t", {"bintest"} )
+        .add_execute("bintest", {"12:34:23.43535"}, request::param_format::text, protocol::format_code::binary, 1);
 
     // Structures to parse the response into
     std::vector<time_row> time_vec;
     response res{into(time_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -190,12 +173,11 @@ static asio::awaitable<void> time_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIME BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
-                  << duration << ")" << std::endl;
+        std::cerr << "TIME BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIME BINARY select result: " << std::format("{0:%T}", time_vec[0].t) << " (in "
-                  << duration << ")" << std::endl;
+        std::cout << "TIME BINARY select result: " << std::format("{0:%T}", time_vec[0].t) << " (in " << duration << ")" << std::endl;
 }
+
 
 // TIMETZ to pg_timetz
 static asio::awaitable<void> timetz_text_example(connection& conn)
@@ -211,7 +193,7 @@ static asio::awaitable<void> timetz_text_example(connection& conn)
     std::vector<timetz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -219,13 +201,10 @@ static asio::awaitable<void> timetz_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMETZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
-                  << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMETZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIMETZ TEXT select result: "
-                  << std::format("{0:%T}", select_vec[0].tz.time_since_midnight) << "+"
-                  << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")"
-                  << std::endl;
+        std::cout << "TIMETZ TEXT select result: " << std::format("{0:%T}", select_vec[0].tz.time_since_midnight) << "+"
+                    << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> timetz_binary_example(connection& conn)
@@ -235,20 +214,14 @@ static asio::awaitable<void> timetz_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::timetz as tz", {"timetz_bintest"})
-        .add_execute(
-            "timetz_bintest",
-            {"12:34:23.43535+05:00"},
-            request::param_format::text,
-            protocol::format_code::binary,
-            1
-        );
+    req.add_prepare("SELECT $1::text::timetz as tz", {"timetz_bintest"} )
+        .add_execute("timetz_bintest", {"12:34:23.43535+05:00"}, request::param_format::text, protocol::format_code::binary, 1);
 
     // Structures to parse the response into
     std::vector<timetz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -256,14 +229,10 @@ static asio::awaitable<void> timetz_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMETZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
-                  << duration << ")" << std::endl;
+        std::cerr << "TIMETZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIMETZ BINARY select result: "
-                  << std::format("{:%T}", select_vec[0].tz.time_since_midnight)
-                  << (select_vec[0].tz.utc_offset.count() > 0 ? "+" : "")
-                  << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")"
-                  << std::endl;
+        std::cout << "TIMETZ BINARY select result: " << std::format("{:%T}", select_vec[0].tz.time_since_midnight)
+                    << (select_vec[0].tz.utc_offset.count() > 0 ? "+"  : "") << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")" << std::endl;
 }
 
 // TIMESTAMP to pg_timestamp
@@ -280,7 +249,7 @@ static asio::awaitable<void> timestamp_text_example(connection& conn)
     std::vector<timestamp_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -288,11 +257,10 @@ static asio::awaitable<void> timestamp_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMP TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
-                  << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMP TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
         std::cout << "TIMESTAMP TEXT select result: " << std::format("{0:%F} {0:%T}", select_vec[0].ts)
-                  << " (in " << duration << ")" << std::endl;
+                    << " (in " << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> timestamp_binary_example(connection& conn)
@@ -302,20 +270,14 @@ static asio::awaitable<void> timestamp_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::timestamp as ts", {"timestamp_bintest"})
-        .add_execute(
-            "timestamp_bintest",
-            {"2026-02-08 12:34:23.43535"},
-            request::param_format::text,
-            protocol::format_code::binary,
-            1
-        );
+    req.add_prepare("SELECT $1::text::timestamp as ts", {"timestamp_bintest"} )
+        .add_execute("timestamp_bintest", {"2026-02-08 12:34:23.43535"}, request::param_format::text, protocol::format_code::binary, 1);
 
     // Structures to parse the response into
     std::vector<timestamp_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -323,12 +285,12 @@ static asio::awaitable<void> timestamp_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMP BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
-                  << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMP BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
         std::cout << "TIMESTAMP BINARY select result: " << std::format("{0:%F} {0:%T}", select_vec[0].ts)
-                  << " (in " << duration << ")" << std::endl;
+                    <<  " (in " << duration << ")" << std::endl;
 }
+
 
 // TIMESTAMPTZ to pg_timestamptz
 static asio::awaitable<void> timestamptz_text_example(connection& conn)
@@ -344,7 +306,7 @@ static asio::awaitable<void> timestamptz_text_example(connection& conn)
     std::vector<timestamptz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -352,12 +314,10 @@ static asio::awaitable<void> timestamptz_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMPTZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
-                  << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMPTZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIMESTAMPTZ TEXT select result: "
-                  << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz) << " (in " << duration << ")"
-                  << std::endl;
+        std::cout << "TIMESTAMPTZ TEXT select result: " << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz)
+                    << " (in " << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> timestamptz_binary_example(connection& conn)
@@ -367,20 +327,14 @@ static asio::awaitable<void> timestamptz_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::timestamptz as tsz", {"timestamptz_bintest"})
-        .add_execute(
-            "timestamptz_bintest",
-            {"2026-02-08 12:34:23.43535+05:00"},
-            request::param_format::text,
-            protocol::format_code::binary,
-            1
-        );
+    req.add_prepare("SELECT $1::text::timestamptz as tsz", {"timestamptz_bintest"} )
+        .add_execute("timestamptz_bintest", {"2026-02-08 12:34:23.43535+05:00"}, request::param_format::text, protocol::format_code::binary, 1);
 
     // Structures to parse the response into
     std::vector<timestamptz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -388,13 +342,12 @@ static asio::awaitable<void> timestamptz_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMPTZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
-                  << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMPTZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIMESTAMPTZ BINARY select result: "
-                  << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz) << " (in " << duration << ")"
-                  << std::endl;
+        std::cout << "TIMESTAMPTZ BINARY select result: " << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz)
+                    <<  " (in " << duration << ")" << std::endl;
 }
+
 
 // INTERVAL to pg_interval (TEXT)
 static asio::awaitable<void> interval_text_example(connection& conn)
@@ -410,7 +363,7 @@ static asio::awaitable<void> interval_text_example(connection& conn)
     std::vector<interval_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -418,12 +371,10 @@ static asio::awaitable<void> interval_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "INTERVAL TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
-                  << " (in " << duration << ")" << std::endl;
+        std::cerr << "INTERVAL TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "INTERVAL TEXT select result: " << select_vec[0].iv.months << " month(s) "
-                  << select_vec[0].iv.days << " day(s) " << std::format("{0:%T}", select_vec[0].iv.time)
-                  << " (in " << duration << ")" << std::endl;
+        std::cout << "INTERVAL TEXT select result: " << select_vec[0].iv.months << " month(s) " << select_vec[0].iv.days << " day(s) " << std::format("{0:%T}", select_vec[0].iv.time)
+                    << " (in " << duration << ")" << std::endl;
 }
 
 // INTERVAL example (BINARY)
@@ -434,20 +385,14 @@ static asio::awaitable<void> interval_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::interval as iv", {"interval_bintest"})
-        .add_execute(
-            "interval_bintest",
-            {"1977 years 6 months 21 days 12:34:23.43535"},
-            request::param_format::text,
-            protocol::format_code::binary,
-            1
-        );
+    req.add_prepare("SELECT $1::text::interval as iv", {"interval_bintest"} )
+        .add_execute("interval_bintest", {"1977 years 6 months 21 days 12:34:23.43535"}, request::param_format::text, protocol::format_code::binary, 1);
 
     // Structures to parse the response into
     std::vector<interval_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -455,13 +400,15 @@ static asio::awaitable<void> interval_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "INTERVAL BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
-                  << duration << ")" << std::endl;
+        std::cerr << "INTERVAL BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "INTERVAL BINARY select result: " << select_vec[0].iv.months << " month(s) "
-                  << select_vec[0].iv.days << " day(s) " << std::format("{0:%T}", select_vec[0].iv.time)
-                  << " (in " << duration << ")" << std::endl;
+        std::cout << "INTERVAL BINARY select result: "
+                    << select_vec[0].iv.months << " month(s) "
+                    << select_vec[0].iv.days << " day(s) "
+                    << std::format("{0:%T}", select_vec[0].iv.time)
+                    <<  " (in " << duration << ")" << std::endl;
 }
+
 
 static asio::awaitable<void> co_main()
 {

--- a/example/datetime.cpp
+++ b/example/datetime.cpp
@@ -82,9 +82,8 @@ static asio::awaitable<void> date_text_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<date_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -109,9 +108,8 @@ static asio::awaitable<void> date_binary_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<date_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -163,9 +161,8 @@ static asio::awaitable<void> time_binary_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<time_row> time_vec;
-    response res{into(time_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(time_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -191,9 +188,8 @@ static asio::awaitable<void> timetz_text_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<timetz_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -219,9 +215,8 @@ static asio::awaitable<void> timetz_binary_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<timetz_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -247,9 +242,8 @@ static asio::awaitable<void> timestamp_text_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<timestamp_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -275,9 +269,8 @@ static asio::awaitable<void> timestamp_binary_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<timestamp_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -304,9 +297,8 @@ static asio::awaitable<void> timestamptz_text_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<timestamptz_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -332,9 +324,8 @@ static asio::awaitable<void> timestamptz_binary_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<timestamptz_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -361,9 +352,8 @@ static asio::awaitable<void> interval_text_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<interval_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -390,9 +380,8 @@ static asio::awaitable<void> interval_binary_example(connection& conn)
 
     // Structures to parse the response into
     std::vector<interval_row> select_vec;
-    response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, into(select_vec), asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();

--- a/example/datetime.cpp
+++ b/example/datetime.cpp
@@ -14,14 +14,14 @@
 #include <boost/asio/this_coro.hpp>
 #include <boost/describe/class.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <exception>
+#include <format>
 #include <iomanip>
 #include <iostream>
 #include <string_view>
 #include <vector>
-#include <chrono>
-#include <format>
 
 #include "nativepg/connection.hpp"
 #include "nativepg/extended_error.hpp"
@@ -33,14 +33,14 @@ using namespace nativepg;
 
 struct date_row
 {
-    //std::chrono::sys_days d;
+    // std::chrono::sys_days d;
     types::pg_date d;
 };
 BOOST_DESCRIBE_STRUCT(date_row, (), (d))
 
 struct time_row
 {
-    //std::chrono::microseconds t;
+    // std::chrono::microseconds t;
     types::pg_time t;
 };
 BOOST_DESCRIBE_STRUCT(time_row, (), (t))
@@ -69,7 +69,6 @@ struct interval_row
 };
 BOOST_DESCRIBE_STRUCT(interval_row, (), (iv))
 
-
 // DATE to std::chrono::days
 static asio::awaitable<void> date_text_example(connection& conn)
 {
@@ -84,7 +83,7 @@ static asio::awaitable<void> date_text_example(connection& conn)
     std::vector<date_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -92,9 +91,11 @@ static asio::awaitable<void> date_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "DATE TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "DATE TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message()
+                  << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "DATE TEXT select result: " << std::format("{0:%F}", select_vec[0].d) << " (in " << duration << ")" << std::endl;
+        std::cout << "DATE TEXT select result: " << std::format("{0:%F}", select_vec[0].d) << " (in "
+                  << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> date_binary_example(connection& conn)
@@ -104,14 +105,20 @@ static asio::awaitable<void> date_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::date as d", {"date_bintest"} )
-        .add_execute("date_bintest", {"1977-06-21"}, request::param_format::text, protocol::format_code::binary, 1);
+    req.add_prepare("SELECT $1::text::date as d", {"date_bintest"})
+        .add_execute(
+            "date_bintest",
+            {"1977-06-21"},
+            request::param_format::text,
+            protocol::format_code::binary,
+            1
+        );
 
     // Structures to parse the response into
     std::vector<date_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -119,9 +126,11 @@ static asio::awaitable<void> date_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "DATE BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "DATE BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
+                  << duration << ")" << std::endl;
     else
-        std::cout << "DATE BINARY select result: " << std::format("{0}", select_vec[0].d) << " (in " << duration << ")" << std::endl;
+        std::cout << "DATE BINARY select result: " << std::format("{0}", select_vec[0].d) << " (in "
+                  << duration << ")" << std::endl;
 }
 
 // TIME to std::chrono::microseconds
@@ -138,7 +147,7 @@ static asio::awaitable<void> time_text_example(connection& conn)
     std::vector<time_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -146,9 +155,11 @@ static asio::awaitable<void> time_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIME TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIME TEXT operation results in Error: " << err.code.what() << ": " << err.diag.message()
+                  << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIME TEXT select result: " << std::format("{0:%T}", select_vec[0].t) << " (in " << duration << ")" << std::endl;
+        std::cout << "TIME TEXT select result: " << std::format("{0:%T}", select_vec[0].t) << " (in "
+                  << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> time_binary_example(connection& conn)
@@ -158,14 +169,20 @@ static asio::awaitable<void> time_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::time as t", {"bintest"} )
-        .add_execute("bintest", {"12:34:23.43535"}, request::param_format::text, protocol::format_code::binary, 1);
+    req.add_prepare("SELECT $1::text::time as t", {"bintest"})
+        .add_execute(
+            "bintest",
+            {"12:34:23.43535"},
+            request::param_format::text,
+            protocol::format_code::binary,
+            1
+        );
 
     // Structures to parse the response into
     std::vector<time_row> time_vec;
     response res{into(time_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -173,11 +190,12 @@ static asio::awaitable<void> time_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIME BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIME BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
+                  << duration << ")" << std::endl;
     else
-        std::cout << "TIME BINARY select result: " << std::format("{0:%T}", time_vec[0].t) << " (in " << duration << ")" << std::endl;
+        std::cout << "TIME BINARY select result: " << std::format("{0:%T}", time_vec[0].t) << " (in "
+                  << duration << ")" << std::endl;
 }
-
 
 // TIMETZ to pg_timetz
 static asio::awaitable<void> timetz_text_example(connection& conn)
@@ -193,7 +211,7 @@ static asio::awaitable<void> timetz_text_example(connection& conn)
     std::vector<timetz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -201,10 +219,13 @@ static asio::awaitable<void> timetz_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMETZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMETZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
+                  << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIMETZ TEXT select result: " << std::format("{0:%T}", select_vec[0].tz.time_since_midnight) << "+"
-                    << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")" << std::endl;
+        std::cout << "TIMETZ TEXT select result: "
+                  << std::format("{0:%T}", select_vec[0].tz.time_since_midnight) << "+"
+                  << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")"
+                  << std::endl;
 }
 
 static asio::awaitable<void> timetz_binary_example(connection& conn)
@@ -214,14 +235,20 @@ static asio::awaitable<void> timetz_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::timetz as tz", {"timetz_bintest"} )
-        .add_execute("timetz_bintest", {"12:34:23.43535+05:00"}, request::param_format::text, protocol::format_code::binary, 1);
+    req.add_prepare("SELECT $1::text::timetz as tz", {"timetz_bintest"})
+        .add_execute(
+            "timetz_bintest",
+            {"12:34:23.43535+05:00"},
+            request::param_format::text,
+            protocol::format_code::binary,
+            1
+        );
 
     // Structures to parse the response into
     std::vector<timetz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -229,10 +256,14 @@ static asio::awaitable<void> timetz_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMETZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMETZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
+                  << duration << ")" << std::endl;
     else
-        std::cout << "TIMETZ BINARY select result: " << std::format("{:%T}", select_vec[0].tz.time_since_midnight)
-                    << (select_vec[0].tz.utc_offset.count() > 0 ? "+"  : "") << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")" << std::endl;
+        std::cout << "TIMETZ BINARY select result: "
+                  << std::format("{:%T}", select_vec[0].tz.time_since_midnight)
+                  << (select_vec[0].tz.utc_offset.count() > 0 ? "+" : "")
+                  << std::format("{:%T}", select_vec[0].tz.utc_offset) << " (in " << duration << ")"
+                  << std::endl;
 }
 
 // TIMESTAMP to pg_timestamp
@@ -249,7 +280,7 @@ static asio::awaitable<void> timestamp_text_example(connection& conn)
     std::vector<timestamp_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -257,10 +288,11 @@ static asio::awaitable<void> timestamp_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMP TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMP TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
+                  << " (in " << duration << ")" << std::endl;
     else
         std::cout << "TIMESTAMP TEXT select result: " << std::format("{0:%F} {0:%T}", select_vec[0].ts)
-                    << " (in " << duration << ")" << std::endl;
+                  << " (in " << duration << ")" << std::endl;
 }
 
 static asio::awaitable<void> timestamp_binary_example(connection& conn)
@@ -270,14 +302,20 @@ static asio::awaitable<void> timestamp_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::timestamp as ts", {"timestamp_bintest"} )
-        .add_execute("timestamp_bintest", {"2026-02-08 12:34:23.43535"}, request::param_format::text, protocol::format_code::binary, 1);
+    req.add_prepare("SELECT $1::text::timestamp as ts", {"timestamp_bintest"})
+        .add_execute(
+            "timestamp_bintest",
+            {"2026-02-08 12:34:23.43535"},
+            request::param_format::text,
+            protocol::format_code::binary,
+            1
+        );
 
     // Structures to parse the response into
     std::vector<timestamp_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -285,12 +323,12 @@ static asio::awaitable<void> timestamp_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMP BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMP BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
+                  << duration << ")" << std::endl;
     else
         std::cout << "TIMESTAMP BINARY select result: " << std::format("{0:%F} {0:%T}", select_vec[0].ts)
-                    <<  " (in " << duration << ")" << std::endl;
+                  << " (in " << duration << ")" << std::endl;
 }
-
 
 // TIMESTAMPTZ to pg_timestamptz
 static asio::awaitable<void> timestamptz_text_example(connection& conn)
@@ -306,7 +344,7 @@ static asio::awaitable<void> timestamptz_text_example(connection& conn)
     std::vector<timestamptz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -314,10 +352,12 @@ static asio::awaitable<void> timestamptz_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMPTZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMPTZ TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
+                  << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "TIMESTAMPTZ TEXT select result: " << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz)
-                    << " (in " << duration << ")" << std::endl;
+        std::cout << "TIMESTAMPTZ TEXT select result: "
+                  << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz) << " (in " << duration << ")"
+                  << std::endl;
 }
 
 static asio::awaitable<void> timestamptz_binary_example(connection& conn)
@@ -327,14 +367,20 @@ static asio::awaitable<void> timestamptz_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::timestamptz as tsz", {"timestamptz_bintest"} )
-        .add_execute("timestamptz_bintest", {"2026-02-08 12:34:23.43535+05:00"}, request::param_format::text, protocol::format_code::binary, 1);
+    req.add_prepare("SELECT $1::text::timestamptz as tsz", {"timestamptz_bintest"})
+        .add_execute(
+            "timestamptz_bintest",
+            {"2026-02-08 12:34:23.43535+05:00"},
+            request::param_format::text,
+            protocol::format_code::binary,
+            1
+        );
 
     // Structures to parse the response into
     std::vector<timestamptz_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -342,12 +388,13 @@ static asio::awaitable<void> timestamptz_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "TIMESTAMPTZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "TIMESTAMPTZ BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
+                  << duration << ")" << std::endl;
     else
-        std::cout << "TIMESTAMPTZ BINARY select result: " << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz)
-                    <<  " (in " << duration << ")" << std::endl;
+        std::cout << "TIMESTAMPTZ BINARY select result: "
+                  << std::format("{0:%F} {0:%T} {0:%Oz}", select_vec[0].tsz) << " (in " << duration << ")"
+                  << std::endl;
 }
-
 
 // INTERVAL to pg_interval (TEXT)
 static asio::awaitable<void> interval_text_example(connection& conn)
@@ -363,7 +410,7 @@ static asio::awaitable<void> interval_text_example(connection& conn)
     std::vector<interval_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -371,10 +418,12 @@ static asio::awaitable<void> interval_text_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "INTERVAL TEXT results in Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "INTERVAL TEXT results in Error: " << err.code.what() << ": " << err.diag.message()
+                  << " (in " << duration << ")" << std::endl;
     else
-        std::cout << "INTERVAL TEXT select result: " << select_vec[0].iv.months << " month(s) " << select_vec[0].iv.days << " day(s) " << std::format("{0:%T}", select_vec[0].iv.time)
-                    << " (in " << duration << ")" << std::endl;
+        std::cout << "INTERVAL TEXT select result: " << select_vec[0].iv.months << " month(s) "
+                  << select_vec[0].iv.days << " day(s) " << std::format("{0:%T}", select_vec[0].iv.time)
+                  << " (in " << duration << ")" << std::endl;
 }
 
 // INTERVAL example (BINARY)
@@ -385,14 +434,20 @@ static asio::awaitable<void> interval_binary_example(connection& conn)
 
     // Compose our request
     request req;
-    req.add_prepare("SELECT $1::text::interval as iv", {"interval_bintest"} )
-        .add_execute("interval_bintest", {"1977 years 6 months 21 days 12:34:23.43535"}, request::param_format::text, protocol::format_code::binary, 1);
+    req.add_prepare("SELECT $1::text::interval as iv", {"interval_bintest"})
+        .add_execute(
+            "interval_bintest",
+            {"1977 years 6 months 21 days 12:34:23.43535"},
+            request::param_format::text,
+            protocol::format_code::binary,
+            1
+        );
 
     // Structures to parse the response into
     std::vector<interval_row> select_vec;
     response res{into(select_vec)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
 
     // Finish timing this method
     auto finish = std::chrono::high_resolution_clock::now();
@@ -400,15 +455,13 @@ static asio::awaitable<void> interval_binary_example(connection& conn)
 
     // Print results
     if (err.extended_error::code != boost::system::errc::success)
-        std::cerr << "INTERVAL BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in " << duration << ")" << std::endl;
+        std::cerr << "INTERVAL BINARY Error: " << err.code.what() << ": " << err.diag.message() << " (in "
+                  << duration << ")" << std::endl;
     else
-        std::cout << "INTERVAL BINARY select result: "
-                    << select_vec[0].iv.months << " month(s) "
-                    << select_vec[0].iv.days << " day(s) "
-                    << std::format("{0:%T}", select_vec[0].iv.time)
-                    <<  " (in " << duration << ")" << std::endl;
+        std::cout << "INTERVAL BINARY select result: " << select_vec[0].iv.months << " month(s) "
+                  << select_vec[0].iv.days << " day(s) " << std::format("{0:%T}", select_vec[0].iv.time)
+                  << " (in " << duration << ")" << std::endl;
 }
-
 
 static asio::awaitable<void> co_main()
 {

--- a/example/dynamic_resultset.cpp
+++ b/example/dynamic_resultset.cpp
@@ -52,9 +52,8 @@ static capy::task<> co_main()
 
     // Structures to parse the response into
     dynamic_resultset res;
-    dynamic_resultset_response handler{res};
 
-    auto [ec2] = co_await conn.exec(req, handler, &diag);
+    auto [ec2] = co_await conn.exec(req, dynamic_resultset_response{res}, &diag);
     if (ec2)
     {
         print_err("Operation result", ec2, diag);

--- a/example/listen.cpp
+++ b/example/listen.cpp
@@ -17,7 +17,6 @@
 #include <vector>
 
 #include "nativepg/co_multiplexed_connection.hpp"
-#include "nativepg/extended_error.hpp"
 #include "nativepg/notification_event.hpp"
 #include "nativepg/request.hpp"
 #include "nativepg/response.hpp"

--- a/example/listen.cpp
+++ b/example/listen.cpp
@@ -20,6 +20,7 @@
 #include "nativepg/extended_error.hpp"
 #include "nativepg/notification_event.hpp"
 #include "nativepg/request.hpp"
+#include "nativepg/response.hpp"
 
 using namespace nativepg;
 namespace capy = boost::capy;
@@ -73,7 +74,7 @@ static capy::io_task<> listener(co_multiplexed_connection& conn)
         // reconnections remove listeners
         if (should_issue_listen(events))
         {
-            if (auto [ec] = co_await conn.exec(req); ec)
+            if (auto [ec] = co_await conn.exec(req, check()); ec)
             {
                 std::cerr << "Error issuing listening: " << ec << ": " << ec.message() << std::endl;
                 co_return {};

--- a/example/nativepg.cpp
+++ b/example/nativepg.cpp
@@ -70,6 +70,10 @@ static asio::awaitable<void> co_main()
     for (const auto& r : vec2)
         std::cout << "Got row (2): " << r.f1 << ", " << r.f3 << std::endl;
 
+    request req2;
+    req2.add_simple_query("SELECT 1");
+    co_await conn.async_exec(req2, check());
+
     std::cout << "Done\n";
 }
 

--- a/example/nativepg.cpp
+++ b/example/nativepg.cpp
@@ -60,7 +60,7 @@ static asio::awaitable<void> co_main()
     std::vector<myrow> vec1, vec2;
     response res{into(vec1), into(vec2)};
 
-    auto [err] = co_await conn.async_exec(req, res, asio::as_tuple);
+    auto [err] = co_await conn.async_exec(req, &res, asio::as_tuple);
     print_err("Operation result: ", err);
     print_err("Q1 result: ", std::get<0>(res.handlers()).result());
     print_err("Q2 result: ", std::get<1>(res.handlers()).result());

--- a/example/prepared_statements.cpp
+++ b/example/prepared_statements.cpp
@@ -70,7 +70,7 @@ static capy::task<> co_main()
     req.add_sync();
 
     // Actually prepare the statements
-    if (auto [ec] = co_await conn.exec(req, &diag); ec)
+    if (auto [ec] = co_await conn.exec(req, check(), &diag); ec)
     {
         print_err("Error preparing", ec, diag);
         co_return;
@@ -83,8 +83,7 @@ static capy::task<> co_main()
     req.add_sync();
 
     std::vector<myrow> rows;
-    response resp{into(rows)};
-    if (auto [ec] = co_await conn.exec(req, resp, &diag); ec)
+    if (auto [ec] = co_await conn.exec(req, into(rows), &diag); ec)
     {
         print_err("Error executing", ec, diag);
         co_return;
@@ -100,7 +99,7 @@ static capy::task<> co_main()
     req.add_close_statement(insert_stmt.name);
     req.add_close_statement(select_stmt.name);
     req.add_sync();
-    if (auto [ec] = co_await conn.exec(req, &diag); ec)
+    if (auto [ec] = co_await conn.exec(req, check(), &diag); ec)
     {
         print_err("Error closing", ec, diag);
         co_return;

--- a/include/nativepg/co_connection.hpp
+++ b/include/nativepg/co_connection.hpp
@@ -111,8 +111,12 @@ public:
         diagnostics* diag = nullptr
     );
 
-    // Like exec(), but checks for errors, ignoring any incoming data
-    boost::capy::io_task<> exec(const request& req, diagnostics* diag = nullptr);
+    template <response_handler ResponseHandler>
+    boost::capy::io_task<> exec(const request& req, ResponseHandler handler, diagnostics* diag = nullptr)
+    {
+        // Keep the handler alive
+        co_return co_await exec(req, response_handler_ref(&handler), diag);
+    }
 
     // The request and the handler must live until the entire response has been read
     // with exec_some

--- a/include/nativepg/co_multiplexed_connection.hpp
+++ b/include/nativepg/co_multiplexed_connection.hpp
@@ -64,7 +64,12 @@ public:
         diagnostics* diag = nullptr
     );
 
-    boost::capy::io_task<> exec(const request& req, diagnostics* diag = nullptr);
+    template <response_handler ResponseHandler>
+    boost::capy::io_task<> exec(const request& req, ResponseHandler handler, diagnostics* diag = nullptr)
+    {
+        // Keep the handler alive
+        co_return co_await exec(req, response_handler_ref(&handler), diag);
+    }
 
     boost::capy::io_task<> read_notifications(std::vector<notification_event>& output);
 };

--- a/include/nativepg/connection.hpp
+++ b/include/nativepg/connection.hpp
@@ -12,6 +12,7 @@
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/compose.hpp>
 #include <boost/asio/connect.hpp>
+#include <boost/asio/consign.hpp>
 #include <boost/asio/deferred.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/write.hpp>
@@ -20,6 +21,8 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #include "nativepg/connect_params.hpp"
 #include "nativepg/extended_error.hpp"
@@ -176,6 +179,21 @@ public:
         },
             token,
             impl_->sock
+        );
+    }
+
+    template <
+        response_handler ResponseHandler,
+        boost::asio::completion_token_for<void(extended_error)> CompletionToken = boost::asio::deferred_t>
+    auto async_exec(const request& req, ResponseHandler&& handler, CompletionToken&& token = {})
+    {
+        // TODO: use associated allocator
+        auto ptr = std::make_unique<std::decay_t<ResponseHandler>>(std::forward<ResponseHandler>(handler));
+        response_handler_ref href{ptr.get()};
+        return async_exec(
+            req,
+            href,
+            boost::asio::consign(std::forward<CompletionToken>(token, std::move(ptr)))
         );
     }
 };

--- a/include/nativepg/connection.hpp
+++ b/include/nativepg/connection.hpp
@@ -193,7 +193,7 @@ public:
         return async_exec(
             req,
             href,
-            boost::asio::consign(std::forward<CompletionToken>(token, std::move(ptr)))
+            boost::asio::consign(std::forward<CompletionToken>(token), std::move(ptr))
         );
     }
 };

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -395,7 +395,9 @@ public:
         requires std::constructible_from<decltype(handlers_), Args&&...>
     explicit response(Args&&... args)
         : handlers_(std::forward<Args>(args)...),
-          vtable_(std::apply([](auto&... h) { return std::array<response_handler_ref, N>{h...}; }, handlers_))
+          vtable_(
+              std::apply([](auto&... h) { return std::array<response_handler_ref, N>{&h...}; }, handlers_)
+          )
     {
     }
 

--- a/include/nativepg/response.hpp
+++ b/include/nativepg/response.hpp
@@ -233,7 +233,7 @@ class resultset_callback_t
     };
 
 public:
-    template <class Cb>
+    template <std::invocable<T&&> Cb>
     explicit resultset_callback_t(Cb&& cb) : cb_(std::forward<Cb>(cb))
     {
     }

--- a/include/nativepg/response_handler.hpp
+++ b/include/nativepg/response_handler.hpp
@@ -106,9 +106,8 @@ class response_handler_ref
 
 public:
     template <response_handler T>
-        requires(!std::same_as<T, response_handler_ref>)
-    response_handler_ref(T& obj) noexcept
-        : obj_(&obj), setup_(&do_setup<T>), on_message_(&do_on_message<T>), result_(&do_result<T>)
+    response_handler_ref(T* obj) noexcept
+        : obj_(obj), setup_(&do_setup<T>), on_message_(&do_on_message<T>), result_(&do_result<T>)
     {
     }
 

--- a/src/co_connection.cpp
+++ b/src/co_connection.cpp
@@ -236,12 +236,6 @@ capy::io_task<> co_connection::exec(const request& req, response_handler_ref han
     }
 }
 
-capy::io_task<> co_connection::exec(const request& req, diagnostics* diag)
-{
-    check handler;
-    co_return co_await exec(req, handler, diag);
-}
-
 void co_connection::setup_request(const request& req, response_handler_ref handler)
 {
     return impl_->setup_request(req, handler);

--- a/src/co_multiplexed_connection.cpp
+++ b/src/co_multiplexed_connection.cpp
@@ -237,12 +237,6 @@ boost::capy::io_task<> nativepg::co_multiplexed_connection::exec(
     return impl_->exec(req, handler, diag);
 }
 
-boost::capy::io_task<> nativepg::co_multiplexed_connection::exec(const request& req, diagnostics* diag)
-{
-    check handler;
-    co_return co_await impl_->exec(req, handler, diag);
-}
-
 boost::capy::io_task<> nativepg::co_multiplexed_connection::read_notifications(
     std::vector<notification_event>& output
 )

--- a/src/nativepg_internal/multiplexed_connection/multiplexer.hpp
+++ b/src/nativepg_internal/multiplexed_connection/multiplexer.hpp
@@ -201,7 +201,7 @@ public:
 
         // In any case, clean up other data members, just in case
         elem->req = nullptr;
-        elem->res = null_handler_;
+        elem->res = &null_handler_;
         elem->on_done = &ignore;
     }
 

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -88,7 +88,7 @@ struct fixture
 {
     request req;
     mock_handler handler;
-    read_response_fsm fsm{&req, handler};
+    read_response_fsm fsm{&req, &handler};
 
     void check(
         std::initializer_list<on_msg_args> expected,


### PR DESCRIPTION
Provides a more ergonomic syntax in common cases
Removes the exec() overloads that don't take a handler, as these are now trivial
Fixes a bug in resultset_callback_t that prevented copy operations from working

