### PR TITLE
Draft supporting contexts and parse_field in resultset_view.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(nativepg_example PRIVATE nativepg)
 add_executable(nativepg_base_example types/base.cpp)
 target_link_libraries(nativepg_base_example PRIVATE nativepg)
 
+add_executable(nativepg_context_example context.cpp)
+target_link_libraries(nativepg_context_example PRIVATE nativepg)
+
 add_executable(nativepg_nullable_example types/nullable.cpp)
 target_link_libraries(nativepg_nullable_example PRIVATE nativepg)
 
@@ -55,5 +58,8 @@ if (NATIVEPG_COROSIO_API)
 
     add_executable(nativepg_resultsets resultsets.cpp)
     target_link_libraries(nativepg_resultsets PRIVATE nativepg_corosio)
+
+    add_executable(nativepg_co_context co_context.cpp)
+    target_link_libraries(nativepg_co_context PRIVATE nativepg_corosio)
 endif()
 

--- a/example/co_context.cpp
+++ b/example/co_context.cpp
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/task.hpp>
+#include <boost/corosio/io_context.hpp>
+
+#include <iostream>
+
+#include "nativepg/co_connection.hpp"
+#include "nativepg/extended_error.hpp"
+#include "nativepg/response.hpp"
+#include "nativepg/context/db_info.hpp"
+#include "nativepg/context/type_info.hpp"
+
+using namespace nativepg;
+namespace capy = boost::capy;
+namespace corosio = boost::corosio;
+
+static void print_err(const char* prefix, std::error_code err, const diagnostics& diag)
+{
+    std::cout << prefix << ": " << err << ": " << err.message();
+    if (!diag.message().empty())
+        std::cout << ": " << diag.message();
+    std::cout << '\n';
+}
+
+static void print_err(const char* prefix, const extended_error& err)
+{
+    print_err(prefix, err.code, err.diag);
+}
+
+static capy::task<> co_main()
+{
+    // Create a connection
+    co_connection conn{co_await capy::this_coro::executor};
+    diagnostics diag;
+
+    // Connect
+    auto [ec] = co_await conn.connect(
+        {.hostname = "localhost", .username = "postgres", .password = "secret", .database = "postgres"},
+        &diag
+    );
+    if (ec)
+    {
+        print_err("Error connecting", ec, diag);
+        co_return;
+    }
+
+    std::cout << "Startup complete\n";
+
+    auto [ec_ctx] = co_await conn.load_contexts<context::db_info_tag, context::type_info_tag>(&diag);
+    if (ec_ctx)
+    {
+        print_err("Error loading contexts", ec_ctx, diag);
+        co_return;
+    }
+
+    auto db_info = context::make_context<context::db_info_tag>();
+    if (!conn.context().resolve<context::db_info_tag>(db_info))
+    {
+        std::cout << "Server version: " << db_info.server_version << std::endl;
+    }
+
+    auto types_info = context::make_context<context::type_info_tag>();
+    if (!conn.context().resolve<context::type_info_tag>(types_info))
+        for (const auto& type_info : types_info)
+    {
+        std::cout << "Type: " << type_info.type_name << ", OID: " << type_info.type_oid << std::endl;
+    }
+}
+
+int main()
+{
+    // The I/O context, required for all I/O operations
+    corosio::io_context ctx;
+
+    // Schedules the main coroutine for execution
+    capy::run_async(
+        ctx.get_executor(),
+        []() {
+           // Runs when the main coroutine finishes normally
+           std::cout << "Done\n";
+        },
+        [](std::exception_ptr exc) {
+            // Runs when the main coroutine finishes with an exception
+            try {
+               std::rethrow_exception(exc);
+            } catch (const std::exception& e) {
+               std::cerr << "Error: " << e.what() << std::endl;
+            }
+            exit(1);
+        }
+    )(co_main());
+
+    // Executes all pending work, including the main coroutine
+    ctx.run();
+}

--- a/example/context.cpp
+++ b/example/context.cpp
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/asio/as_tuple.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/address_v4.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/this_coro.hpp>
+#include <boost/describe/class.hpp>
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include "nativepg/connection.hpp"
+#include "nativepg/extended_error.hpp"
+#include "nativepg/request.hpp"
+#include "nativepg/response.hpp"
+#include "nativepg/context/db_info.hpp"
+#include "nativepg/context/type_info.hpp"
+
+namespace asio = boost::asio;
+using namespace nativepg;
+
+static void print_err(const char* prefix, const extended_error& err)
+{
+    std::cout << prefix << err.code.what() << ": " << err.diag.message() << '\n';
+}
+
+static asio::awaitable<void> co_main()
+{
+    // Create a connection
+    connection conn{co_await asio::this_coro::executor};
+
+    // Connect
+    co_await conn.async_connect(
+        {.hostname = "localhost", .username = "postgres", .password = "secret", .database = "postgres"}
+    );
+    std::cout << "Startup complete\n";
+
+    // Load contexts
+    auto [err] = co_await conn.async_load_contexts<context::db_info_tag, context::type_info_tag>(boost::asio::as_tuple);
+    std::cout << "Contexts loaded\n";
+
+    auto db_info = context::make_context<context::db_info_tag>();
+    if (!conn.context().resolve<context::db_info_tag>(db_info))
+    {
+        std::cout << "Server version: " << db_info.server_version << std::endl;
+    }
+
+    auto types_info = context::make_context<context::type_info_tag>();
+    if (!conn.context().resolve<context::type_info_tag>(types_info))
+    {
+        for (const auto& type_info : types_info)
+        {
+            std::cout << "Type: " << type_info.type_name << ", OID: " << type_info.type_oid << std::endl;
+        }
+    }
+
+    std::cout << "Done\n";
+}
+
+int main()
+{
+    asio::io_context ctx;
+
+    asio::co_spawn(ctx, co_main(), [](std::exception_ptr exc) {
+        if (exc)
+            std::rethrow_exception(exc);
+    });
+
+    ctx.run();
+}

--- a/include/nativepg/client_errc.hpp
+++ b/include/nativepg/client_errc.hpp
@@ -114,6 +114,9 @@ enum class client_errc : int
     // You issued a COPY SQL statement through an API that doesn't support COPY operations.
     // Use an appropriate API, instead
     copy_not_allowed,
+
+    // get<tag>(...) is called but context is not found in cache. Call load_context first.
+    context_not_found
 };
 
 /// Creates an \ref error_code from a \ref client_errc.

--- a/include/nativepg/co_connection.hpp
+++ b/include/nativepg/co_connection.hpp
@@ -18,12 +18,15 @@
 #include <memory>
 #include <span>
 
+#include "nativepg/context/context.hpp"
 #include "nativepg/connect_params.hpp"
+#include "nativepg/dynamic_resultset.hpp"
 #include "nativepg/extended_error.hpp"
 #include "nativepg/protocol/connection_state.hpp"
 #include "nativepg/protocol/copy.hpp"
 #include "nativepg/protocol/startup_fsm.hpp"
 #include "nativepg/request.hpp"
+#include "nativepg/response.hpp"
 #include "nativepg/response_handler.hpp"
 
 namespace nativepg {
@@ -85,6 +88,7 @@ class co_connection
 {
     struct impl;
     std::unique_ptr<impl> impl_;
+    context::context ctx_;
 
 public:
     explicit co_connection(boost::capy::execution_context& ctx);
@@ -130,6 +134,41 @@ public:
     // TODO: I don't like this
     boost::capy::any_stream& stream();
     protocol::connection_state& state();
+
+    template <context::ValidStateTag... Tags>
+    [[nodiscard]] boost::capy::io_task<> load_contexts(diagnostics* diag = nullptr) noexcept {
+        context::query_collector collector{};
+
+        // Collect phase via unrolled compile-time lambda folding
+        auto collect_loader = [&collector](auto tag_identity) {
+            using Tag = typename decltype(tag_identity)::type;
+            using Loader = context::context_state_loader<Tag>;
+
+            collector.add_query(
+                Loader::get_query(),
+                [](const resultset_view& result, diagnostics* diag) noexcept -> std::unique_ptr<context::context_state> {
+                    return Loader::parse(result, diag);
+                }
+            );
+        };
+        (collect_loader(std::type_identity<Tags>{}), ...);
+
+        // Batch SQL run against PostgreSQL wrapper
+        resultsets res{};
+        auto [ec] = co_await exec(collector.combined_queries, resultsets_handler{res}, diag);
+        if (!ec && res.size() == collector.parsers.size()) {
+            // Hydration loop driving out-parameter state updates
+            for (size_t i = 0; i < collector.parsers.size(); ++i) {
+                std::unique_ptr<context::context_state> state = collector.parsers[i](res[i], diag);
+                if (!ec)
+                    ctx_.commit_state(std::move(state));
+            }
+        }
+
+        co_return {};
+    }
+
+    context::context& context() noexcept { return ctx_; }
 };
 
 }  // namespace nativepg

--- a/include/nativepg/connection.hpp
+++ b/include/nativepg/connection.hpp
@@ -16,7 +16,10 @@
 #include <boost/asio/deferred.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/write.hpp>
-#include <boost/system/error_code.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/as_tuple.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -32,6 +35,7 @@
 #include "nativepg/protocol/startup_fsm.hpp"
 #include "nativepg/request.hpp"
 #include "nativepg/response_handler.hpp"
+#include "nativepg/context/context.hpp"
 
 namespace nativepg {
 
@@ -148,6 +152,7 @@ struct exec_op
 class connection
 {
     std::unique_ptr<detail::connection_impl> impl_;
+    context::context ctx_;
 
 public:
     explicit connection(boost::asio::any_io_executor ex) : impl_(new detail::connection_impl{std::move(ex)})
@@ -195,6 +200,88 @@ public:
             href,
             boost::asio::consign(std::forward<CompletionToken>(token), std::move(ptr))
         );
+    }
+
+    template <context::ValidStateTag... Tags, typename CompletionToken = boost::asio::deferred_t>
+    [[nodiscard]] auto async_load_contexts(CompletionToken&& token = {}) noexcept {
+        // 1. Initiate a standard asynchronous composed operation using Asio's helper
+        return boost::asio::async_initiate<CompletionToken, void(extended_error)>(
+            [this](auto handler) {
+                // Get the executor from your underlying connection or target token handler
+                auto exec = boost::asio::get_associated_executor(handler, this->get_executor());
+
+                // 2. Spawn the internal coroutine helper onto the active executor pipeline
+                boost::asio::co_spawn(exec,
+                    [this]() -> boost::asio::awaitable<extended_error> {
+                        co_return co_await this->impl_async_load_contexts<Tags...>();
+                    },
+                    [moved_handler = std::move(handler)](std::exception_ptr ep, extended_error err) mutable {
+                        if (ep) {
+                            // Safe fallback if an unexpected runtime breakdown happens
+                            moved_handler(extended_error{client_errc::unexpected_message});
+                        } else {
+                            // Pass your structured error code straight back to the token line
+                            moved_handler(err);
+                        }
+                    }
+                );
+            },
+            token
+        );
+    }
+
+    context::context& context() noexcept { return ctx_; }
+
+private:
+    template <context::ValidStateTag... Tags>
+    [[nodiscard]] boost::asio::awaitable<extended_error> impl_async_load_contexts() noexcept {
+        context::query_collector collector{};
+
+        // Collect phase via unrolled compile-time lambda folding
+        auto collect_loader = [&collector](auto tag_identity) {
+            using Tag = typename decltype(tag_identity)::type;
+            using Loader = context::context_state_loader<Tag>;
+
+            collector.add_query(
+                Loader::get_query(),
+                [](const resultset_view& result, diagnostics* diag) noexcept -> std::unique_ptr<context::context_state> {
+                    return Loader::parse(result, diag);
+                }
+            );
+        };
+        (collect_loader(std::type_identity<Tags>{}), ...);
+
+        resultsets res{};
+
+        auto [err] = co_await async_exec(
+            collector.combined_queries,
+            resultsets_handler{res},
+            boost::asio::as_tuple
+        );
+
+        // Check if the query execution returned a database or network failure
+        if (err.code) {
+            co_return err;
+        }
+
+        // Check if the number of result sets matches our queries
+        if (res.size() != collector.parsers.size()) {
+            co_return extended_error{client_errc::unexpected_message};
+        }
+
+        // Hydration loop driving out-parameter state updates
+        for (size_t i = 0; i < collector.parsers.size(); ++i) {
+            diagnostics diag{};
+            std::unique_ptr<context::context_state> state = collector.parsers[i](res[i], &diag);
+
+            if (state) {
+                ctx_.commit_state(std::move(state));
+            } else {
+                co_return extended_error{client_errc::incomplete_message};
+            }
+        }
+
+        co_return extended_error{}; // Return clean success code
     }
 };
 

--- a/include/nativepg/context/context.hpp
+++ b/include/nativepg/context/context.hpp
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef NATIVEPG_CONTEXT_CONTEXT_HPP
+#define NATIVEPG_CONTEXT_CONTEXT_HPP
+
+#include <concepts>
+#include <memory>
+#include <span>
+
+#include "nativepg/connect_params.hpp"
+#include "nativepg/dynamic_resultset.hpp"
+#include "nativepg/extended_error.hpp"
+#include "nativepg/protocol/startup_fsm.hpp"
+#include "nativepg/request.hpp"
+#include "nativepg/response.hpp"
+
+namespace nativepg::context {
+
+    // --- Polymorphic Heap-Allocated State Base ---
+    struct context_state {
+        virtual ~context_state() = default;
+        [[nodiscard]] virtual const void* get_type_id() const noexcept = 0;
+    };
+
+    template <typename Tag>
+    struct context_state_loader {
+        static_assert(sizeof(Tag) == 0, "Context loader not found for this tag.");
+    };
+
+    // --- The C++20 Verified Loader Interface Blueprint ---
+    template <typename Tag>
+    concept ValidStateTag = requires(const resultset_view& rows, diagnostics* diag) {
+        typename context_state_loader<Tag>::state_type;
+        { context_state_loader<Tag>::get_query() } -> std::same_as<std::string>;
+        { context_state_loader<Tag>::parse(rows, diag) } -> std::same_as<std::unique_ptr<typename context_state_loader<Tag>::state_type>>;
+    };
+
+// --- The Query Aggregator Registry ---
+struct query_collector {
+    request combined_queries{};
+
+    // Callbacks match the boost signature
+    using HydrateCallback = std::function<std::unique_ptr<context_state>(const resultset_view&, diagnostics*)>;
+    std::vector<HydrateCallback> parsers;
+
+    inline void add_query(const std::string_view& sql, HydrateCallback parser_func) {
+        combined_queries.add_query(sql, {}); // TODO: setting parameters?
+        parsers.push_back(std::move(parser_func));
+    }
+};
+
+// --- Runtime Storage Connection Context ---
+class context {
+private:
+    static constexpr size_t MAX_CACHED_STATES = 16;
+    std::unique_ptr<context_state> cache_slots[MAX_CACHED_STATES];
+    size_t active_slots_count = 0;
+
+    template <typename StateType>
+    [[nodiscard]] StateType* find_cached_state() noexcept {
+        for (size_t i = 0; i < active_slots_count; ++i) {
+            if (cache_slots[i] && cache_slots[i]->get_type_id() == &typeid(StateType)) {
+                return static_cast<StateType*>(cache_slots[i].get());
+            }
+        }
+        return nullptr;
+    }
+
+public:
+    void commit_state(std::unique_ptr<context_state> fresh_state) noexcept {
+        if (!fresh_state) return;
+        const void* target_id = fresh_state->get_type_id();
+
+        for (size_t i = 0; i < active_slots_count; ++i) {
+            if (cache_slots[i] && cache_slots[i]->get_type_id() == target_id) {
+                cache_slots[i] = std::move(fresh_state);
+                return;
+            }
+        }
+
+        if (active_slots_count < MAX_CACHED_STATES) {
+            cache_slots[active_slots_count] = std::move(fresh_state);
+            ++active_slots_count;
+        }
+    }
+
+    template <ValidStateTag Tag>
+    [[nodiscard]] boost::system::error_code resolve(typename context_state_loader<Tag>::state_type& ctx) noexcept {
+        using concrete_state = typename context_state_loader<Tag>::state_type;
+        auto* ptr = find_cached_state<concrete_state>();
+        if (!ptr) {
+            return client_errc::context_not_found;
+        }
+        ctx = *ptr;
+        return {};
+    }
+};
+
+template <ValidStateTag Tag>
+[[nodiscard]] auto make_context() noexcept
+{
+    return typename context_state_loader<Tag>::state_type{};
+}
+
+}  // namespace nativepg::context
+
+#endif

--- a/include/nativepg/context/db_info.hpp
+++ b/include/nativepg/context/db_info.hpp
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef NATIVEPG_CONTEXT_DB_INFO_HPP
+#define NATIVEPG_CONTEXT_DB_INFO_HPP
+
+#include <string>
+
+#include "context.hpp"
+#include "nativepg/dynamic_resultset.hpp"
+
+namespace nativepg::context {
+
+
+struct db_info_tag {};
+template <>
+struct context_state_loader<db_info_tag> {
+    struct state_type : public context_state {
+        std::string database_name;
+        std::string encoding;
+        std::string collation;
+        std::string ctype;
+        std::string server_version;
+        std::string search_path;
+
+        [[nodiscard]] const void* get_type_id() const noexcept override { return &typeid(state_type); }
+    };
+
+    static std::string get_query() noexcept {
+        return R"sql(
+            SELECT
+                current_database() AS database_name,
+                pg_encoding_to_char(encoding) AS encoding,
+                datcollate AS collation,
+                datctype AS ctype,
+                current_setting('server_version') AS server_version,
+                current_setting('search_path') AS search_path
+            FROM pg_catalog.pg_database
+            WHERE datname = current_database();
+            )sql";
+    }
+
+    static std::unique_ptr<state_type> parse(const resultset_view& result, diagnostics* diag) noexcept {
+        state_type state;
+        state.database_name = std::string(result.rows()[0][0].data_str());
+        state.encoding = std::string(result.rows()[0][1].data_str());
+        state.collation = std::string(result.rows()[0][2].data_str());
+        state.ctype = std::string(result.rows()[0][3].data_str());
+        state.server_version = std::string(result.rows()[0][4].data_str());
+        state.search_path = std::string(result.rows()[0][5].data_str());
+        return std::make_unique<state_type>(state);
+    }
+};
+
+}
+
+#endif

--- a/include/nativepg/context/type_info.hpp
+++ b/include/nativepg/context/type_info.hpp
@@ -1,0 +1,142 @@
+//
+// Copyright (c) 2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef NATIVEPG_CONTEXT_TYPE_INFO_HPP
+#define NATIVEPG_CONTEXT_TYPE_INFO_HPP
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "nativepg/context/context.hpp"
+#include "nativepg/dynamic_resultset.hpp"
+
+namespace nativepg::context {
+
+
+struct type_info_tag {};
+template <>
+struct context_state_loader<type_info_tag> {
+    struct state_type : public context_state {
+        struct record
+        {
+            std::uint32_t type_oid;
+            std::string schema_name;
+            std::string type_name;
+            std::optional<std::string> extension_name; // NULL if it is a native built-in type or independent UDT
+            std::optional<std::int16_t> schema_path_seqno; // Only return the search_path sequence number if the type is explicitly visible in the search_path
+            std::optional<std::uint32_t> array_element_oid; // NULL if it is not an array
+            char type; // 'e' for enum, 'd' for domain, 'c' for composite, 'p' for pseudo-type
+            std::int16_t storage_bytes; // Storage size in bytes. Returns -1 if the size is variable-length (like text)
+        };
+        std::vector<record> types;
+
+        [[nodiscard]] auto begin() const { return types.begin(); }
+        [[nodiscard]] auto cbegin() const { return types.cbegin(); }
+        [[nodiscard]] auto end() const { return types.end(); }
+        [[nodiscard]] auto cend() const { return types.cend(); }
+
+        [[nodiscard]] const void* get_type_id() const noexcept override { return &typeid(state_type); }
+    };
+
+    static std::string get_query() noexcept {
+        return R"sql(
+            WITH path_order AS (
+                -- Unnest the search path and assign sequence numbers
+                SELECT
+                    schema_name,
+                    ordinality::int2 AS seqno
+                FROM unnest(current_schemas(false)) WITH ORDINALITY AS t(schema_name, ordinality)
+            ),
+            type_extensions AS (
+                -- Resolve which types belong to which extensions via pg_depend
+                SELECT
+                    objid AS type_oid,
+                    ext.extname AS extension_name
+                FROM pg_catalog.pg_depend dep
+                JOIN pg_catalog.pg_extension ext ON dep.refobjid = ext.oid
+                WHERE dep.classid = 'pg_catalog.pg_type'::regclass
+                  AND dep.refclassid = 'pg_catalog.pg_extension'::regclass
+                  AND dep.deptype = 'e' -- 'e' means the object is an internal part of the extension
+            )
+            SELECT
+                -- oid is unique in database
+                t.oid AS type_oid,
+                -- type name is unique in schema
+                n.nspname AS schema_name,
+                t.typname AS type_name,
+                ext.extension_name, -- NULL if it is a native built-in type or independent UDT
+                -- Only return the search_path sequence number if the type is explicitly visible in the search_path
+                CASE
+                    WHEN pg_catalog.pg_type_is_visible(t.oid) THEN p.seqno
+                    ELSE NULL
+                END AS schema_path_seqno,
+                -- Is it an array? True if the type has an element type and typlen is variable (-1)
+                CASE
+                    WHEN t.typlen = -1 and t.typelem !=0 THEN t.typelem
+                    ELSE NULL
+                END AS array_element_oid,
+                -- Is it an Enum type? ('e' stands for enum in typtype)
+                -- Is it a Domain type? ('d' stands for domain in typtype)
+                -- Is it a Composite type? ('c' stands for composite in typtype)
+                -- Is it a Pseudo-type? ('p' stands for pseudo-type in typtype, like record, void)
+                t.typtype as type,
+                -- Storage size in bytes. Returns -1 if the size is variable-length (like text)
+                t.typlen AS storage_bytes
+            FROM pg_catalog.pg_type t
+            JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+            -- Left join ensures we see ALL types, even if they aren't in the active search_path
+            LEFT JOIN path_order p ON p.schema_name = n.nspname
+            LEFT JOIN type_extensions ext ON ext.type_oid = t.oid
+            WHERE
+                -- 0. We don't want the static oids
+                t.oid >= 16384
+            AND
+                -- 1. Exclude composite types directly tied to real tables, views, or foreign tables
+                (t.typrelid = 0 OR EXISTS (
+                    SELECT 1
+                    FROM pg_catalog.pg_class c
+                    WHERE c.oid = t.typrelid AND c.relkind = 'c' -- Keep only standalone composite types
+                ))
+                -- 2. Exclude the automatic array types generated for those table composite types
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM pg_catalog.pg_type base
+                    JOIN pg_catalog.pg_class c ON c.oid = base.typrelid
+                    WHERE base.oid = t.typelem
+                      AND c.relkind != 'c'
+                )
+            ORDER BY
+                type_name,
+                schema_path_seqno nulls last -- < Get first type in schema_path
+            ;
+            )sql";
+    }
+
+    static std::unique_ptr<state_type> parse(const resultset_view& result, diagnostics* diag) noexcept {
+        state_type state;
+        for (std::size_t r = 0; r < result.rows().size(); ++r) {
+            std::size_t f = 0;
+            state_type::record type{};
+            // TODO: This is ugly!
+            boost::system::error_code ec = result.parse_field<std::uint32_t>(r, f++, type.type_oid);
+            ec = result.parse_field<std::string>(r, f++, type.schema_name);
+            ec = result.parse_field<std::string>(r, f++, type.type_name);
+            ec = result.parse_field<std::optional<std::string>>(r, f++, type.extension_name);
+            ec = result.parse_field<std::optional<std::int16_t>>(r, f++, type.schema_path_seqno);
+            ec = result.parse_field<std::optional<std::uint32_t>>(r, f++, type.array_element_oid);
+            ec = result.parse_field<char>(r, f++, type.type);
+            ec = result.parse_field<std::int16_t>(r, f++, type.storage_bytes);
+            state.types.push_back(type);
+        }
+        return std::make_unique<state_type>(state);
+    }
+};
+
+}
+
+#endif

--- a/include/nativepg/dynamic_resultset.hpp
+++ b/include/nativepg/dynamic_resultset.hpp
@@ -25,6 +25,7 @@
 #include "nativepg/protocol/data_row.hpp"
 #include "nativepg/protocol/describe.hpp"
 #include "nativepg/protocol/views.hpp"
+#include "nativepg/detail/field_traits.hpp"
 
 // TODO: separate compilation
 
@@ -573,6 +574,20 @@ public:
     const command_info& info() const { return result_->info; }
 
     const extended_error& error() const { return result_->err; }
+
+
+    // TODO: Improve this method!
+    template<typename FieldType>
+    boost::system::error_code parse_field(std::size_t row_offset, std::size_t field_offset, FieldType& to) const
+    {
+        auto fd = (descr_ + result_->descr.offset + field_offset)->to_field_description(data_);
+        auto ec = detail::field_is_compatible<FieldType>::call(fd);
+        if (ec)
+            return ec;
+        auto fv = (values_ + result_->values.offset + row_offset * result_->descr.length + field_offset)->to_field_view(data_);
+        return detail::field_parse<FieldType>::call(fv, fd, to);
+    }
+
 };
 
 // A sequence of resultsets. Can accommodate the response to any number of SQL commands


### PR DESCRIPTION
Contexts are meant to quickly load and keep context data during, or right after start complete.

Also altered the dynamic resultset to support parse_field from the context.

This PR is meant as alternative / replacement for PR #61. Using the proper context inside the field_parse methods is for another PR.

Implemented both for asio and for coriso.

Again everything is discusable. This PR is just a tryout.

Some highlights:
The build-in db_info_tag looks as follows:
```c++
struct db_info_tag {};
template <>
struct context_state_loader<db_info_tag> {
    struct state_type : public context_state {
        std::string database_name;
        std::string encoding;
        std::string collation;
        std::string ctype;
        std::string server_version;
        std::string search_path;

        [[nodiscard]] const void* get_type_id() const noexcept override { return &typeid(state_type); }
    };

    static std::string get_query() noexcept {
        return R"sql(
            SELECT
                current_database() AS database_name,
                pg_encoding_to_char(encoding) AS encoding,
                datcollate AS collation,
                datctype AS ctype,
                current_setting('server_version') AS server_version,
                current_setting('search_path') AS search_path
            FROM pg_catalog.pg_database
            WHERE datname = current_database();
            )sql";
    }

    static std::unique_ptr<state_type> parse(const resultset_view& result, diagnostics* diag) noexcept {
        state_type state;
        state.database_name = std::string(result.rows()[0][0].data_str());
        state.encoding = std::string(result.rows()[0][1].data_str());
        state.collation = std::string(result.rows()[0][2].data_str());
        state.ctype = std::string(result.rows()[0][3].data_str());
        state.server_version = std::string(result.rows()[0][4].data_str());
        state.search_path = std::string(result.rows()[0][5].data_str());
        return std::make_unique<state_type>(state);
    }
};
```

Usage in context.cpp example:
```c++
    // Load contexts
    auto [err] = co_await conn.async_load_contexts<context::db_info_tag, context::type_info_tag>(boost::asio::as_tuple);
    std::cout << "Contexts loaded\n";

    // Resolve and use the context
    auto db_info = context::make_context<context::db_info_tag>();
    if (!conn.context().resolve<context::db_info_tag>(db_info))
    {
        std::cout << "Server version: " << db_info.server_version << std::endl;
    }
```

With my Postgresql db it shows:
```plain
Contexts loaded
Server version: 18.4 (Homebrew)
```