### PR TITLE
Serialization traits can now express NULL values

### DIFF
--- a/doc/rationales.md
+++ b/doc/rationales.md
@@ -39,3 +39,43 @@ On the other hand, parameter type OIDs are specified in `parse` messages.
 It is common to send `parse` independently of `bind` - this is the case when
 preparing a statement and executing it later. For this reason,
 it is inviable to embed the type's OID in `serializable_ref`.
+
+## Why not split deserialization into two functions in the traits - one for text and another for binary?
+
+Simplicity. When parsing, the protocol gives you:
+
+- The type OID of what you are parsing - represented as an `std::int32_t`.
+- The format code of what you are parsing - represented as a `format_code`.
+- The raw bytes of the value, plus a flag indicating whether the value is `NULL` - represented as a `field_view`.
+
+The current traits structure intend to be as close to the protocol as possible.
+It is true that this creates some duplication, especially regarding `NULL` checks.
+We find this acceptable because writing traits is a specialized task - most users will never do it.
+The alternative would be splitting types into nullable/non-nullable, with
+different signatures. We think the complexity is not worth it.
+
+A similar argument applies to serialization.
+
+## Why does serialization represent NULL as a special error code?
+
+This is the simplest and most robust alternative. Another option would be
+changing `serializable_ref` to hold a special value when the contained type
+is `NULL`. But this:
+
+- Complicates `serializable_ref` - `function_ref` cannot hold an empty value
+  like `std::function` does.
+- Complicates serialization traits. A new function `bool is_null(const T& value)`
+  would be required, with almost all types returning `false`.
+- Makes the serialization function for nullable types less robust:
+
+```cpp
+// Serialization functions for std::optional<T>
+static bool is_null(const std::optional<T>& value) { return !value.has_value(); }
+static std::error_code serialize(const std::optional<T>& value, std::vector<unsigned char>& to) {
+    // Trust that is_null was called correctly
+    return field_serialize<T>(*value, to);
+}
+```
+
+Recall that `std::error_code` values can represent conditions
+that are not necessarily fatal errors - e.g. EOF.

--- a/include/nativepg/client_errc.hpp
+++ b/include/nativepg/client_errc.hpp
@@ -119,6 +119,11 @@ enum class client_errc : int
     // and parameters passed to a bind message. Either use a single
     // format code for all parameters, or the same number of codes than parameters.
     num_format_codes_mismatch,
+
+    // A serialization function tried to serialize a value,
+    // but the value is NULL. Mostly used as a sentinel by serialization
+    // functions to signal that a NULL should be serialized.
+    serialize_null,
 };
 
 /// Creates an \ref error_code from a \ref client_errc.

--- a/include/nativepg/detail/field_traits_base.hpp
+++ b/include/nativepg/detail/field_traits_base.hpp
@@ -20,6 +20,7 @@
 #include "nativepg/client_errc.hpp"
 #include "nativepg/field_traits.hpp"
 #include "nativepg/field_view.hpp"
+#include "nativepg/protocol/common.hpp"
 #include "nativepg/types/base.hpp"
 
 namespace nativepg::detail {
@@ -69,20 +70,18 @@ struct parse_field_traits<bool>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, [[maybe_unused]] std::int32_t type_oid, bool& to)
+    static std::error_code parse(
+        field_view from,
+        [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
+        bool& to
+    )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::bool_oid);
-        return types::parse_text_bool(from, to);
-    }
-
-    static std::error_code parse_binary(field_view from, [[maybe_unused]] std::int32_t type_oid, bool& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::bool_oid);
-        return types::parse_binary_bool(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_bool(from, to)
+                                                     : types::parse_text_bool(from, to);
     }
 };
 
@@ -98,28 +97,18 @@ struct parse_field_traits<std::vector<std::byte>>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         std::vector<std::byte>& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::bytea_oid);
-        return types::parse_text_bytea(from, to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        std::vector<std::byte>& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::bytea_oid);
-        return types::parse_binary_bytea(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_bytea(from, to)
+                                                     : types::parse_text_bytea(from, to);
     }
 };
 
@@ -136,20 +125,18 @@ struct parse_field_traits<char>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, [[maybe_unused]] std::int32_t type_oid, char& to)
+    static std::error_code parse(
+        field_view from,
+        [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
+        char& to
+    )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::char_oid);
-        return types::parse_text_char(from, to);
-    }
-
-    static std::error_code parse_binary(field_view from, [[maybe_unused]] std::int32_t type_oid, char& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::char_oid);
-        return types::parse_binary_char(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_char(from, to)
+                                                     : types::parse_text_char(from, to);
     }
 };
 
@@ -165,28 +152,18 @@ struct parse_field_traits<std::int16_t>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         std::int16_t& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::int2_oid);
-        return types::parse_text_int(from, to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        std::int16_t& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::int2_oid);
-        return types::parse_binary_int(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_int(from, to)
+                                                     : types::parse_text_int(from, to);
     }
 };
 
@@ -202,39 +179,28 @@ struct parse_field_traits<std::int32_t>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, std::int32_t type_oid, std::int32_t& to)
+    static std::error_code parse(
+        field_view from,
+        std::int32_t type_oid,
+        protocol::format_code code,
+        std::int32_t& to
+    )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
+        const bool binary = code == protocol::format_code::binary;
         switch (type_oid)
         {
             case detail::int2_oid:
             {
                 std::int16_t value{};
-                const auto ec = types::parse_text_int(from, value);
+                const auto ec = binary ? types::parse_binary_int(from, value)
+                                       : types::parse_text_int(from, value);
                 to = value;
                 return ec;
             }
-            case detail::int4_oid: return types::parse_text_int(from, to);
-
-            default: BOOST_ASSERT(false); return {client_errc::incompatible_field_type};
-        }
-    }
-
-    static std::error_code parse_binary(field_view from, std::int32_t type_oid, std::int32_t& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        switch (type_oid)
-        {
-            case detail::int2_oid:
-            {
-                std::int16_t value{};
-                const auto ec = types::parse_binary_int(from, value);
-                to = value;
-                return ec;
-            }
-            case detail::int4_oid: return types::parse_binary_int(from, to);
+            case detail::int4_oid:
+                return binary ? types::parse_binary_int(from, to) : types::parse_text_int(from, to);
 
             default: BOOST_ASSERT(false); return {client_errc::incompatible_field_type};
         }
@@ -253,52 +219,36 @@ struct parse_field_traits<std::int64_t>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, std::int32_t type_oid, std::int64_t& to)
+    static std::error_code parse(
+        field_view from,
+        std::int32_t type_oid,
+        protocol::format_code code,
+        std::int64_t& to
+    )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
+        const bool binary = code == protocol::format_code::binary;
         switch (type_oid)
         {
             case detail::int2_oid:
             {
                 std::int16_t value{};
-                const auto ec = types::parse_text_int(from, value);
+                const auto ec = binary ? types::parse_binary_int(from, value)
+                                       : types::parse_text_int(from, value);
                 to = value;
                 return ec;
             }
             case detail::int4_oid:
             {
                 std::int32_t value{};
-                const auto ec = types::parse_text_int(from, value);
+                const auto ec = binary ? types::parse_binary_int(from, value)
+                                       : types::parse_text_int(from, value);
                 to = value;
                 return ec;
             }
-            case detail::int8_oid: return types::parse_text_int(from, to);
-            default: BOOST_ASSERT(false); return {client_errc::incompatible_field_type};
-        }
-    }
-
-    static std::error_code parse_binary(field_view from, std::int32_t type_oid, std::int64_t& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        switch (type_oid)
-        {
-            case detail::int2_oid:
-            {
-                std::int16_t value{};
-                const auto ec = types::parse_binary_int(from, value);
-                to = value;
-                return ec;
-            }
-            case detail::int4_oid:
-            {
-                std::int32_t value{};
-                const auto ec = types::parse_binary_int(from, value);
-                to = value;
-                return ec;
-            }
-            case detail::int8_oid: return types::parse_binary_int(from, to);
+            case detail::int8_oid:
+                return binary ? types::parse_binary_int(from, to) : types::parse_text_int(from, to);
             default: BOOST_ASSERT(false); return {client_errc::incompatible_field_type};
         }
     }
@@ -316,20 +266,18 @@ struct parse_field_traits<float>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, [[maybe_unused]] std::int32_t type_oid, float& to)
+    static std::error_code parse(
+        field_view from,
+        [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
+        float& to
+    )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::float4_oid);
-        return types::parse_text_float<float>(from, to);
-    }
-
-    static std::error_code parse_binary(field_view from, [[maybe_unused]] std::int32_t type_oid, float& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::float4_oid);
-        return types::parse_binary_float<float>(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_float<float>(from, to)
+                                                     : types::parse_text_float<float>(from, to);
     }
 };
 
@@ -345,35 +293,26 @@ struct parse_field_traits<double>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, [[maybe_unused]] std::int32_t type_oid, double& to)
+    static std::error_code parse(
+        field_view from,
+        [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
+        double& to
+    )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
+        const bool binary = code == protocol::format_code::binary;
         switch (type_oid)
         {
-            case detail::float8_oid: return types::parse_text_float<double>(from, to);
+            case detail::float8_oid:
+                return binary ? types::parse_binary_float<double>(from, to)
+                              : types::parse_text_float<double>(from, to);
             case detail::float4_oid:
             {
                 float value{};
-                const auto ec = types::parse_text_float<float>(from, value);
-                to = value;
-                return ec;
-            }
-            default: BOOST_ASSERT(false); return {client_errc::incompatible_field_type};
-        }
-    }
-
-    static std::error_code parse_binary(field_view from, [[maybe_unused]] std::int32_t type_oid, double& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        switch (type_oid)
-        {
-            case detail::float8_oid: return types::parse_binary_float<double>(from, to);
-            case detail::float4_oid:
-            {
-                float value{};
-                const auto ec = types::parse_binary_float<float>(from, value);
+                const auto ec = binary ? types::parse_binary_float<float>(from, value)
+                                       : types::parse_text_float<float>(from, value);
                 to = value;
                 return ec;
             }
@@ -394,28 +333,18 @@ struct parse_field_traits<std::basic_string<char, Traits, Alloc>>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         std::basic_string<char, Traits, Alloc>& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(detail::is_string_oid(type_oid));
-        return types::parse_text_text(from, to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        std::basic_string<char, Traits, Alloc>& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(detail::is_string_oid(type_oid));
-        return types::parse_binary_text(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_text(from, to)
+                                                     : types::parse_text_text(from, to);
     }
 };
 
@@ -431,28 +360,18 @@ struct parse_field_traits<std::uint32_t>
         return client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         std::uint32_t& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::oid_oid);
-        return types::parse_text_oid(from, to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        std::uint32_t& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::oid_oid);
-        return types::parse_binary_oid(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_oid(from, to)
+                                                     : types::parse_text_oid(from, to);
     }
 };
 
@@ -466,14 +385,14 @@ struct serialize_field_traits<std::int16_t>
 {
     static constexpr std::int32_t oid = detail::int2_oid;
 
-    static std::error_code serialize_text(std::int16_t value, std::vector<unsigned char>& to)
+    static std::error_code serialize(
+        std::int16_t value,
+        protocol::format_code code,
+        std::vector<unsigned char>& to
+    )
     {
-        return types::serialize_text_int(value, to);
-    }
-
-    static std::error_code serialize_binary(std::int16_t value, std::vector<unsigned char>& to)
-    {
-        return types::serialize_binary_int(value, to);
+        return code == protocol::format_code::binary ? types::serialize_binary_int(value, to)
+                                                     : types::serialize_text_int(value, to);
     }
 };
 
@@ -483,14 +402,14 @@ struct serialize_field_traits<std::int32_t>
 {
     static constexpr std::int32_t oid = detail::int4_oid;
 
-    static std::error_code serialize_text(std::int32_t value, std::vector<unsigned char>& to)
+    static std::error_code serialize(
+        std::int32_t value,
+        protocol::format_code code,
+        std::vector<unsigned char>& to
+    )
     {
-        return types::serialize_text_int(value, to);
-    }
-
-    static std::error_code serialize_binary(std::int32_t value, std::vector<unsigned char>& to)
-    {
-        return types::serialize_binary_int(value, to);
+        return code == protocol::format_code::binary ? types::serialize_binary_int(value, to)
+                                                     : types::serialize_text_int(value, to);
     }
 };
 
@@ -500,14 +419,14 @@ struct serialize_field_traits<std::int64_t>
 {
     static constexpr std::int32_t oid = detail::int8_oid;
 
-    static std::error_code serialize_text(std::int64_t value, std::vector<unsigned char>& to)
+    static std::error_code serialize(
+        std::int64_t value,
+        protocol::format_code code,
+        std::vector<unsigned char>& to
+    )
     {
-        return types::serialize_text_int(value, to);
-    }
-
-    static std::error_code serialize_binary(std::int64_t value, std::vector<unsigned char>& to)
-    {
-        return types::serialize_binary_int(value, to);
+        return code == protocol::format_code::binary ? types::serialize_binary_int(value, to)
+                                                     : types::serialize_text_int(value, to);
     }
 };
 
@@ -517,14 +436,14 @@ struct serialize_field_traits<T>
 {
     static constexpr std::int32_t oid = detail::text_oid;
 
-    static std::error_code serialize_text(std::string_view value, std::vector<unsigned char>& to)
+    static std::error_code serialize(
+        std::string_view value,
+        protocol::format_code code,
+        std::vector<unsigned char>& to
+    )
     {
-        return types::serialize_text_text(value, to);
-    }
-
-    static std::error_code serialize_binary(std::string_view value, std::vector<unsigned char>& to)
-    {
-        return types::serialize_binary_text(value, to);
+        return code == protocol::format_code::binary ? types::serialize_binary_text(value, to)
+                                                     : types::serialize_text_text(value, to);
     }
 };
 

--- a/include/nativepg/detail/field_traits_datetime.hpp
+++ b/include/nativepg/detail/field_traits_datetime.hpp
@@ -19,6 +19,7 @@
 #include "nativepg/client_errc.hpp"
 #include "nativepg/field_traits.hpp"
 #include "nativepg/field_view.hpp"
+#include "nativepg/protocol/common.hpp"
 #include "nativepg/types.hpp"
 
 namespace nativepg::detail {
@@ -38,8 +39,8 @@ inline constexpr std::int32_t daterange_oid = 3912;
 namespace nativepg {
 
 // --- Parse
-// There is no serialization counterpart yet: nativepg/types/datetime.hpp implements
-// parsing only.
+// There is no serialization counterpart: nativepg/types/datetime.hpp implements parsing only,
+// so these types can't be used as query parameters yet.
 
 // DATE
 template <>
@@ -50,28 +51,18 @@ struct parse_field_traits<std::chrono::sys_days>
         return type_oid == detail::date_oid ? std::error_code() : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         std::chrono::sys_days& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::date_oid);
-        return types::parse_text_date(from.data(), to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        std::chrono::sys_days& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::date_oid);
-        return types::parse_binary_date(from.data(), to);
+        return code == protocol::format_code::binary ? types::parse_binary_date(from.data(), to)
+                                                     : types::parse_text_date(from.data(), to);
     }
 };
 
@@ -84,28 +75,18 @@ struct parse_field_traits<std::chrono::microseconds>
         return type_oid == detail::time_oid ? std::error_code() : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         std::chrono::microseconds& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::time_oid);
-        return types::parse_text_time(from.data(), to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        std::chrono::microseconds& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::time_oid);
-        return types::parse_binary_time(from.data(), to);
+        return code == protocol::format_code::binary ? types::parse_binary_time(from.data(), to)
+                                                     : types::parse_text_time(from.data(), to);
     }
 };
 
@@ -118,28 +99,18 @@ struct parse_field_traits<types::pg_timetz>
         return type_oid == detail::timetz_oid ? std::error_code() : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         types::pg_timetz& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::timetz_oid);
-        return types::parse_text_timetz(from.data(), to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        types::pg_timetz& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::timetz_oid);
-        return types::parse_binary_timetz(from.data(), to);
+        return code == protocol::format_code::binary ? types::parse_binary_timetz(from.data(), to)
+                                                     : types::parse_text_timetz(from.data(), to);
     }
 };
 
@@ -152,28 +123,18 @@ struct parse_field_traits<types::pg_timestamp>
         return type_oid == detail::timestamp_oid ? std::error_code() : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         types::pg_timestamp& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::timestamp_oid);
-        return types::parse_text_timestamp(from.data(), to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        types::pg_timestamp& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::timestamp_oid);
-        return types::parse_binary_timestamp(from.data(), to);
+        return code == protocol::format_code::binary ? types::parse_binary_timestamp(from.data(), to)
+                                                     : types::parse_text_timestamp(from.data(), to);
     }
 };
 
@@ -186,28 +147,18 @@ struct parse_field_traits<types::pg_timestamptz>
         return type_oid == detail::timestamptz_oid ? std::error_code() : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         types::pg_timestamptz& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::timestamptz_oid);
-        return types::parse_text_timestamptz(from.data(), to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        types::pg_timestamptz& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::timestamptz_oid);
-        return types::parse_binary_timestamptz(from.data(), to);
+        return code == protocol::format_code::binary ? types::parse_binary_timestamptz(from.data(), to)
+                                                     : types::parse_text_timestamptz(from.data(), to);
     }
 };
 
@@ -220,28 +171,18 @@ struct parse_field_traits<types::pg_interval>
         return type_oid == detail::interval_oid ? std::error_code() : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         types::pg_interval& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::interval_oid);
-        return types::parse_text_interval(from.data(), to);
-    }
-
-    static std::error_code parse_binary(
-        field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
-        types::pg_interval& to
-    )
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::interval_oid);
-        return types::parse_binary_interval(from.data(), to);
+        return code == protocol::format_code::binary ? types::parse_binary_interval(from.data(), to)
+                                                     : types::parse_text_interval(from.data(), to);
     }
 };
 

--- a/include/nativepg/detail/field_traits_decimal.hpp
+++ b/include/nativepg/detail/field_traits_decimal.hpp
@@ -23,6 +23,7 @@
 #include "nativepg/extended_error.hpp"
 #include "nativepg/field_traits.hpp"
 #include "nativepg/field_view.hpp"
+#include "nativepg/protocol/common.hpp"
 #include "nativepg/types/decimal.hpp"
 
 namespace nativepg::detail {
@@ -40,8 +41,8 @@ concept is_decimal = std::same_as<T, boost::decimal::decimal32_t> ||
 namespace nativepg {
 
 // --- Parse
-// There is no serialization counterpart yet: nativepg/types/decimal.hpp implements
-// parsing only.
+// There is no serialization counterpart: nativepg/types/decimal.hpp implements parsing only,
+// so these types can't be used as query parameters yet.
 
 // NUMERIC
 template <detail::is_decimal T>
@@ -52,20 +53,18 @@ struct parse_field_traits<T>
         return type_oid == detail::decimal_oid ? std::error_code{} : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, [[maybe_unused]] std::int32_t type_oid, T& to)
+    static std::error_code parse(
+        field_view from,
+        [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
+        T& to
+    )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::decimal_oid);
-        return types::parse_text_decimal(from, to);
-    }
-
-    static std::error_code parse_binary(field_view from, [[maybe_unused]] std::int32_t type_oid, T& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::decimal_oid);
-        return types::parse_binary_decimal(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_decimal(from, to)
+                                                     : types::parse_text_decimal(from, to);
     }
 };
 

--- a/include/nativepg/detail/field_traits_json.hpp
+++ b/include/nativepg/detail/field_traits_json.hpp
@@ -20,6 +20,7 @@
 #include "nativepg/client_errc.hpp"
 #include "nativepg/field_traits.hpp"
 #include "nativepg/field_view.hpp"
+#include "nativepg/protocol/common.hpp"
 #include "nativepg/types/json.hpp"
 
 namespace nativepg::detail {
@@ -32,8 +33,8 @@ inline constexpr std::int32_t jsonb_oid = 3802;
 namespace nativepg {
 
 // --- Parse
-// There is no serialization counterpart yet: nativepg/types/json.hpp implements
-// parsing only.
+// There is no serialization counterpart: nativepg/types/json.hpp implements parsing only,
+// so these types can't be used as query parameters yet.
 
 // JSON(B) => boost::json::value
 template <>
@@ -46,9 +47,10 @@ struct parse_field_traits<boost::json::value>
                    : client_errc::incompatible_field_type;
     }
 
-    static inline std::error_code parse_text(
+    static inline std::error_code parse(
         field_view from,
-        [[maybe_unused]] std::int32_t type_oid,
+        std::int32_t type_oid,
+        protocol::format_code code,
         boost::json::value& to
     )
     {
@@ -56,25 +58,11 @@ struct parse_field_traits<boost::json::value>
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::json_oid || type_oid == detail::jsonb_oid);
 
-        // Both json and jsonb use plain JSON as their text representation
-        return types::parse_json(from.data_str(), to);
-    }
-
-    static inline std::error_code parse_binary(field_view from, std::int32_t type_oid, boost::json::value& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-
-        // The binary representation of json is plain JSON, while jsonb has a version prefix
-        if (type_oid == detail::jsonb_oid)
-        {
+        // Both json and jsonb use plain JSON as their text representation. The same holds
+        // for the binary representation of json, while binary jsonb has a version prefix
+        if (code == protocol::format_code::binary && type_oid == detail::jsonb_oid)
             return types::parse_binary_jsonb(from, to);
-        }
-        else
-        {
-            BOOST_ASSERT(type_oid == detail::json_oid);
-            return types::parse_json(from.data_str(), to);
-        }
+        return types::parse_json(from.data_str(), to);
     }
 };
 

--- a/include/nativepg/detail/field_traits_nullable.hpp
+++ b/include/nativepg/detail/field_traits_nullable.hpp
@@ -14,9 +14,12 @@
 #include <optional>
 #include <system_error>
 #include <type_traits>
+#include <vector>
 
+#include "nativepg/client_errc.hpp"
 #include "nativepg/field_traits.hpp"
 #include "nativepg/field_view.hpp"
+#include "nativepg/protocol/common.hpp"
 
 namespace nativepg::detail {
 
@@ -39,9 +42,6 @@ inline constexpr auto is_optional_v = is_optional<T>::value;
 namespace nativepg {
 
 // --- Parse
-// A NULL field yields an empty optional, rather than an error.
-// There is no serialization counterpart yet: serialize_field_traits has no way
-// to express a NULL parameter.
 template <parsable_field T>
 struct parse_field_traits<std::optional<T>>
 {
@@ -52,24 +52,42 @@ struct parse_field_traits<std::optional<T>>
 
     static std::error_code is_compatible(std::int32_t type_oid) { return field_is_compatible<T>(type_oid); }
 
-    static std::error_code parse_text(field_view from, std::int32_t type_oid, std::optional<T>& to)
+    static std::error_code parse(
+        field_view from,
+        std::int32_t type_oid,
+        protocol::format_code code,
+        std::optional<T>& to
+    )
     {
         if (from.is_null())
         {
             to.reset();
             return std::error_code{};
         }
-        return field_parse_text(from, type_oid, to.emplace());
+        return field_parse(from, type_oid, code, to.emplace());
     }
+};
 
-    static std::error_code parse_binary(field_view from, std::int32_t type_oid, std::optional<T>& to)
+// --- Serialize
+template <serializable_field T>
+struct serialize_field_traits<std::optional<T>>
+{
+    static_assert(
+        !detail::is_optional_v<T>,
+        "Nested std::optional (e.g. std::optional<std::optional<T>>) is not supported"
+    );
+
+    // A NULL has no type of its own, so we advertise the value type's OID
+    static constexpr std::int32_t oid = field_serialize_oid<T>;
+
+    static std::error_code serialize(
+        const std::optional<T>& value,
+        protocol::format_code code,
+        std::vector<unsigned char>& to
+    )
     {
-        if (from.is_null())
-        {
-            to.reset();
-            return std::error_code{};
-        }
-        return field_parse_binary(from, type_oid, to.emplace());
+        // serialize_null indicates that a NULL value should be serialized (not an error)
+        return value.has_value() ? field_serialize(*value, code, to) : client_errc::serialize_null;
     }
 };
 

--- a/include/nativepg/detail/field_traits_numeric.hpp
+++ b/include/nativepg/detail/field_traits_numeric.hpp
@@ -21,6 +21,7 @@
 #include "nativepg/extended_error.hpp"
 #include "nativepg/field_traits.hpp"
 #include "nativepg/field_view.hpp"
+#include "nativepg/protocol/common.hpp"
 #include "nativepg/types/numeric.hpp"
 
 namespace nativepg::detail {
@@ -32,8 +33,8 @@ inline constexpr std::int32_t numeric_oid = 1700;
 namespace nativepg {
 
 // --- Parse
-// There is no serialization counterpart yet: nativepg/types/numeric.hpp implements
-// parsing only.
+// There is no serialization counterpart: nativepg/types/numeric.hpp implements parsing only,
+// so these types can't be used as query parameters yet.
 
 // NUMERIC
 template <unsigned Digits, class Exp, class Alloc, boost::multiprecision::expression_template_option ET>
@@ -48,24 +49,18 @@ struct parse_field_traits<
         return type_oid == detail::numeric_oid ? std::error_code{} : client_errc::incompatible_field_type;
     }
 
-    static std::error_code parse_text(field_view from, [[maybe_unused]] std::int32_t type_oid, value_type& to)
-    {
-        if (from.is_null())
-            return client_errc::unexpected_null;
-        BOOST_ASSERT(type_oid == detail::numeric_oid);
-        return types::parse_text_numeric(from, to);
-    }
-
-    static std::error_code parse_binary(
+    static std::error_code parse(
         field_view from,
         [[maybe_unused]] std::int32_t type_oid,
+        protocol::format_code code,
         value_type& to
     )
     {
         if (from.is_null())
             return client_errc::unexpected_null;
         BOOST_ASSERT(type_oid == detail::numeric_oid);
-        return types::parse_binary_numeric(from, to);
+        return code == protocol::format_code::binary ? types::parse_binary_numeric(from, to)
+                                                     : types::parse_text_numeric(from, to);
     }
 };
 

--- a/include/nativepg/field_traits.hpp
+++ b/include/nativepg/field_traits.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "nativepg/field_view.hpp"
+#include "nativepg/protocol/common.hpp"
 
 namespace nativepg {
 
@@ -38,18 +39,13 @@ struct is_unspecialized
  *
  *    static std::error_code is_compatible(std::int32_t type_oid);
  *
- *  - parse_text: performs the actual parsing, for fields sent by the server
- *    using the text format. Returns an error if the value can't be represented
- *    in your type. type_oid is the OID that is_compatible accepted, and is
- *    relevant if your type accepts more than one. field_view is non-owning and
+ *  - parse: performs the actual parsing. Returns an error if the value can't be
+ *    represented in your type. type_oid is the OID that is_compatible accepted, and is
+ *    relevant if your type accepts more than one. code states whether the server sent
+ *    the field using the text or the binary format. field_view is non-owning and
  *    can represent database NULLs - remember to check for these. Signature:
  *
- *    static std::error_code parse_text(field_view, std::int32_t type_oid, T&)
- *
- *  - parse_binary: same, but for fields sent using the binary format.
- *    Signature:
- *
- *    static std::error_code parse_binary(field_view, std::int32_t type_oid, T&)
+ *    static std::error_code parse(field_view, std::int32_t type_oid, protocol::format_code code, T&)
  *
  */
 template <class T>
@@ -69,15 +65,15 @@ struct parse_field_traits : detail::is_unspecialized
  *    when using the binary format. For example, a 2-byte integer type
  *    should be assigned the int2 type OID.
  *
- *  - serialize_text: serialized the value into a buffer, using the text
- *    format. If the value is not representable in the corresponding protocol
- *    type, an error can be returned. Signature:
+ *  - serialize: appends the value to a buffer, using the format stated by code.
+ *    If the value is not representable in the corresponding protocol type, an error
+ *    can be returned. Signature:
  *
- *    static std::error_code serialize_text(const T& value, std::vector<unsigned char>& buffer)
+ *    static std::error_code serialize(
+ *        const T& value, protocol::format_code code, std::vector<unsigned char>& buffer)
  *
- *  - serialize_binary: same, but using the binary format. Signature:
- *
- *    static std::error_code serialize_binary(const T& value, std::vector<unsigned char>& buffer)
+ *    To express that the value is a SQL NULL, return client_errc::serialize_null
+ *    without appending anything to the buffer.
  */
 template <class T>
 struct serialize_field_traits : detail::is_unspecialized
@@ -100,17 +96,10 @@ concept parsable_field =
         { parse_field_traits<T>::is_compatible(std::int32_t{}) } -> std::convertible_to<std::error_code>;
 
         // If you are seeing an error message pointing to this expression,
-        // your parse_text function in the parse_field_traits specialization
+        // your parse function in the parse_field_traits specialization
         // for your type is missing or has an incorrect shape.
         {
-            parse_field_traits<T>::parse_text(field_view{}, std::int32_t{}, value)
-        } -> std::convertible_to<std::error_code>;
-
-        // If you are seeing an error message pointing to this expression,
-        // your parse_binary function in the parse_field_traits specialization
-        // for your type is missing or has an incorrect shape.
-        {
-            parse_field_traits<T>::parse_binary(field_view{}, std::int32_t{}, value)
+            parse_field_traits<T>::parse(field_view{}, std::int32_t{}, protocol::format_code{}, value)
         } -> std::convertible_to<std::error_code>;
     };
 
@@ -128,14 +117,11 @@ concept serializable_field =
         { serialize_field_traits<T>::oid } -> std::convertible_to<std::int32_t>;
 
         // If you are seeing an error message pointing to this expression,
-        // your serialize_text function in the serialize_field_traits specialization
+        // your serialize function in the serialize_field_traits specialization
         // for your type is missing or has an incorrect shape.
-        { serialize_field_traits<T>::serialize_text(value, to) } -> std::convertible_to<std::error_code>;
-
-        // If you are seeing an error message pointing to this expression,
-        // your serialize_binary function in the serialize_field_traits specialization
-        // for your type is missing or has an incorrect shape.
-        { serialize_field_traits<T>::serialize_binary(value, to) } -> std::convertible_to<std::error_code>;
+        {
+            serialize_field_traits<T>::serialize(value, protocol::format_code{}, to)
+        } -> std::convertible_to<std::error_code>;
     };
 
 // Now if you, as a user, want to add support for a type, you specialize any of these.
@@ -148,30 +134,18 @@ std::error_code field_is_compatible(std::int32_t type_oid)
 }
 
 template <parsable_field T>
-std::error_code field_parse_text(field_view from, std::int32_t type_oid, T& to)
+std::error_code field_parse(field_view from, std::int32_t type_oid, protocol::format_code code, T& to)
 {
-    return parse_field_traits<T>::parse_text(from, type_oid, to);
-}
-
-template <parsable_field T>
-std::error_code field_parse_binary(field_view from, std::int32_t type_oid, T& to)
-{
-    return parse_field_traits<T>::parse_binary(from, type_oid, to);
+    return parse_field_traits<T>::parse(from, type_oid, code, to);
 }
 
 template <serializable_field T>
 inline constexpr std::int32_t field_serialize_oid = serialize_field_traits<T>::oid;
 
 template <serializable_field T>
-std::error_code field_serialize_text(const T& value, std::vector<unsigned char>& to)
+std::error_code field_serialize(const T& value, protocol::format_code code, std::vector<unsigned char>& to)
 {
-    return serialize_field_traits<T>::serialize_text(value, to);
-}
-
-template <serializable_field T>
-std::error_code field_serialize_binary(const T& value, std::vector<unsigned char>& to)
-{
-    return serialize_field_traits<T>::serialize_binary(value, to);
+    return serialize_field_traits<T>::serialize(value, code, to);
 }
 
 }  // namespace nativepg

--- a/include/nativepg/protocol/bind.hpp
+++ b/include/nativepg/protocol/bind.hpp
@@ -10,7 +10,6 @@
 
 #include <boost/compat/function_ref.hpp>
 
-#include <optional>
 #include <span>
 #include <string_view>
 #include <system_error>
@@ -22,9 +21,9 @@
 namespace nativepg {
 namespace protocol {
 
-// TODO: rename all this and wrap this
-using serializable_ref = std::optional<
-    boost::compat::function_ref<std::error_code(format_code, std::vector<unsigned char>&)>>;
+// A type-erased reference to a bind parameter value.
+using serializable_ref = boost::compat::function_ref<
+    std::error_code(format_code, std::vector<unsigned char>&)>;
 
 struct bind
 {
@@ -38,7 +37,7 @@ struct bind
     format_codes parameter_fmt_codes;
 
     // The actual parameters. The number of parameters must match the number of parameters required by the
-    // query. An empty optional is serialized as a NULL value.
+    // query. A parameter that reports client_errc::serialize_null is serialized as a NULL value.
     std::span<const serializable_ref> parameters;
 
     // The result-column format codes.

--- a/include/nativepg/request.hpp
+++ b/include/nativepg/request.hpp
@@ -53,15 +53,6 @@ struct statement
 
 namespace detail {
 
-template <serializable_field T>
-std::error_code do_field_serialize(const T& value, protocol::format_code code, std::vector<unsigned char>& to)
-{
-    if (code == protocol::format_code::binary)
-        return serialize_field_traits<T>::serialize_binary(value, to);
-    else
-        return serialize_field_traits<T>::serialize_text(value, to);
-}
-
 template <serializable_field... Params>
 inline constexpr std::array<std::int32_t, sizeof...(Params)> type_oids_for{{field_serialize_oid<Params>...}};
 
@@ -72,12 +63,7 @@ protocol::serializable_ref make_serializable_ref(const T* value)
 {
     // Required for C-array parameters to work (and hence string literals)
     using decayed_type = std::decay_t<const T&>;
-
-    // TODO: nullness check
-    return boost::compat::function_ref<std::error_code(protocol::format_code, std::vector<unsigned char>&)>{
-        boost::compat::nontype<detail::do_field_serialize<decayed_type>>,
-        *value
-    };
+    return protocol::serializable_ref{boost::compat::nontype<field_serialize<decayed_type>>, *value};
 }
 
 // Type-erases each parameter into a serializable_ref.

--- a/include/nativepg/responses/resultset_callback.hpp
+++ b/include/nativepg/responses/resultset_callback.hpp
@@ -158,9 +158,7 @@ class resultset_callback_t
             detail::for_each_member(row, [&ec, &idx, &self = this->self](auto& member) {
                 const detail::pos_map_entry& ent = self.pos_map_[idx++];
                 const field_view fv = self.random_access_data_.at(ent.db_index);
-                std::error_code ec2 = ent.fmt_code == protocol::format_code::text
-                                          ? field_parse_text(fv, ent.type_oid, member)
-                                          : field_parse_binary(fv, ent.type_oid, member);
+                std::error_code ec2 = field_parse(fv, ent.type_oid, ent.fmt_code, member);
                 if (!ec)
                     ec = ec2;
             });

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -56,6 +56,7 @@ static const char* error_to_string(client_errc error)
         case client_errc::needs_more: return "needs_more";
         case client_errc::copy_not_allowed: return "copy_not_allowed";
         case client_errc::num_format_codes_mismatch: return "num_format_codes_mismatch";
+        case client_errc::serialize_null: return "serialize_null";
         default: return "<unknown nativepg client error>";
     }
 }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -787,20 +787,22 @@ void serialize_params(
     auto& buffer = ctx.buffer();
     for (std::size_t i = 0; i < params.size(); ++i)
     {
-        const auto& param = params[i];
-        if (!param.has_value())
-        {
-            ctx.add_integral(static_cast<std::int32_t>(-1));
-            continue;
-        }
-
         // Allocate space for the size, which is not known until the value has been serialized
         const std::size_t size_offset = buffer.size();
         ctx.add_bytes(std::array<unsigned char, 4>{});
 
         // Serialize the value
-        if (auto ec = (*param)(format_code_for(codes, i), buffer))
+        if (auto ec = params[i](format_code_for(codes, i), buffer))
         {
+            // This is not a failure, but the parameter stating that it's a SQL NULL.
+            // Discard anything it may have written and encode it as a -1 size
+            if (ec == nativepg::client_errc::serialize_null)
+            {
+                buffer.resize(size_offset);
+                ctx.add_integral(static_cast<std::int32_t>(-1));
+                continue;
+            }
+
             ctx.add_error(ec);
             return;
         }

--- a/test/unit/test_request.cpp
+++ b/test/unit/test_request.cpp
@@ -10,8 +10,10 @@
 
 #include <cstdint>
 #include <initializer_list>
+#include <optional>
 #include <ostream>
 #include <source_location>
+#include <span>
 #include <string_view>
 
 #include "nativepg/protocol/bind.hpp"
@@ -242,6 +244,127 @@ void test_execute_untyped()
             request_message_type::sync,
         }
     );
+}
+
+// NULL parameters. An empty optional is encoded as a -1 length, followed by no value bytes
+void test_execute_null_text()
+{
+    request req;
+    req.add_execute(
+        "myname",
+        make_serializable_refs(std::optional<std::int32_t>(), "value"),
+        {.param_format = protocol::format_code::text}
+    );
+
+    // clang-format off
+    check_payload(req, {
+        // Bind. Note the 0xffffffff length for the 1st parameter, with no value bytes
+        0x42, 0x00, 0x00, 0x00, 0x1f, 0x00, 0x6d, 0x79, 0x6e, 0x61,
+        0x6d, 0x65, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xff, 0xff,
+        0xff, 0x00, 0x00, 0x00, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65,
+        0x00, 0x00,
+
+        // Describe
+        0x44, 0x00, 0x00, 0x00, 0x06, 0x50, 0x00,
+
+        // Execute
+        0x45, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+        // Sync
+        0x53, 0x00, 0x00, 0x00, 0x04
+    });
+    // clang-format on
+
+    check_messages(
+        req,
+        {
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
+        }
+    );
+}
+
+// A NULL is encoded the same way regardless of the format code. This also checks
+// that the lengths of the surrounding parameters are unaffected
+void test_execute_null_binary_mixed()
+{
+    request req;
+    req.add_execute(
+        "s",
+        make_serializable_refs(
+            std::int32_t(1),
+            std::optional<std::int32_t>(),
+            std::optional<std::int32_t>(7)
+        ),
+        {.param_format = protocol::format_code::binary}
+    );
+
+    // clang-format off
+    check_payload(req, {
+        // Bind
+        0x42, 0x00, 0x00, 0x00, 0x23, 0x00, 0x73, 0x00, 0x00, 0x01,
+        0x00, 0x01, 0x00, 0x03,
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01,  // 1
+        0xff, 0xff, 0xff, 0xff,                          // NULL
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x07,  // 7
+        0x00, 0x00,
+
+        // Describe
+        0x44, 0x00, 0x00, 0x00, 0x06, 0x50, 0x00,
+
+        // Execute
+        0x45, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+        // Sync
+        0x53, 0x00, 0x00, 0x00, 0x04
+    });
+    // clang-format on
+
+    check_messages(
+        req,
+        {
+            request_message_type::bind,
+            request_message_type::describe,
+            request_message_type::execute,
+            request_message_type::sync,
+        }
+    );
+}
+
+// A per-parameter list of format codes applies each code to its own parameter
+void test_execute_format_code_list()
+{
+    constexpr protocol::format_code codes[]{protocol::format_code::text, protocol::format_code::binary};
+
+    request req;
+    req.add_execute(
+        "myname",
+        make_serializable_refs(std::int32_t(42), std::int32_t(42)),
+        {.param_format = std::span<const protocol::format_code>(codes)}
+    );
+
+    // clang-format off
+    check_payload(req, {
+        // Bind. The same value is serialized as text and as binary
+        0x42, 0x00, 0x00, 0x00, 0x24, 0x00, 0x6d, 0x79, 0x6e, 0x61,
+        0x6d, 0x65, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00,
+        0x02,
+        0x00, 0x00, 0x00, 0x02, 0x34, 0x32,              // "42"
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x2a,  // 42
+        0x00, 0x00,
+
+        // Describe
+        0x44, 0x00, 0x00, 0x00, 0x06, 0x50, 0x00,
+
+        // Execute
+        0x45, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+        // Sync
+        0x53, 0x00, 0x00, 0x00, 0x04
+    });
+    // clang-format on
 }
 
 void test_execute_typed()
@@ -499,6 +622,9 @@ int main()
     test_prepare_typed();
 
     test_execute_untyped();
+    test_execute_null_text();
+    test_execute_null_binary_mixed();
+    test_execute_format_code_list();
     test_execute_typed();
     test_execute_typed_optional_args();
 

--- a/test/unit/types/test_base.cpp
+++ b/test/unit/types/test_base.cpp
@@ -14,6 +14,7 @@
 #include <iomanip>
 #include <limits>
 #include <optional>
+#include <source_location>
 #include <span>
 #include <sstream>
 #include <string>
@@ -23,7 +24,9 @@
 
 #include "nativepg/client_errc.hpp"
 #include "nativepg/field_traits.hpp"
+#include "nativepg/protocol/common.hpp"
 #include "nativepg/types/base.hpp"
+#include "test_utils/test_range_eq.hpp"
 
 using namespace nativepg;
 using std::error_code;
@@ -608,7 +611,7 @@ void test_parse_binary_text_success(const T& in_val)
 }
 
 //
-// field_is_compatible / field_parse_text / field_parse_binary (field_traits_base.hpp)
+// field_is_compatible / field_parse (field_traits_base.hpp)
 //
 void test_field_is_compatible_bool_success()
 {
@@ -684,7 +687,7 @@ void test_field_parse_text_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_text(fv, detail::bool_oid, b);
+    auto err = field_parse(fv, detail::bool_oid, protocol::format_code::text, b);
 
     // Assert
     BOOST_TEST_EQ(err, error_code(client_errc::unexpected_null));
@@ -697,7 +700,7 @@ void test_field_parse_binary_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_binary(fv, detail::bool_oid, b);
+    auto err = field_parse(fv, detail::bool_oid, protocol::format_code::binary, b);
 
     // Assert
     BOOST_TEST_EQ(err, error_code(client_errc::unexpected_null));
@@ -712,7 +715,7 @@ void test_field_parse_text_bool_success()
     field_view fv{data};
 
     // Act
-    auto err = field_parse_text(fv, detail::bool_oid, b);
+    auto err = field_parse(fv, detail::bool_oid, protocol::format_code::text, b);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code());
@@ -728,7 +731,7 @@ void test_field_parse_text_char_success()
     field_view fv{data};
 
     // Act
-    auto err = field_parse_text(fv, detail::char_oid, c);
+    auto err = field_parse(fv, detail::char_oid, protocol::format_code::text, c);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code());
@@ -742,7 +745,7 @@ void test_field_parse_text_char_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_text(fv, detail::char_oid, c);
+    auto err = field_parse(fv, detail::char_oid, protocol::format_code::text, c);
 
     // Assert
     BOOST_TEST_EQ(err, error_code(client_errc::unexpected_null));
@@ -757,7 +760,7 @@ void test_field_parse_text_oid_success()
     field_view fv{data};
 
     // Act
-    auto err = field_parse_text(fv, detail::oid_oid, o);
+    auto err = field_parse(fv, detail::oid_oid, protocol::format_code::text, o);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code());
@@ -771,7 +774,7 @@ void test_field_parse_text_oid_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_text(fv, detail::oid_oid, o);
+    auto err = field_parse(fv, detail::oid_oid, protocol::format_code::text, o);
 
     // Assert
     BOOST_TEST_EQ(err, error_code(client_errc::unexpected_null));
@@ -786,7 +789,7 @@ void test_field_parse_binary_int32_from_int2_wire_success()
     field_view fv{data};
 
     // Act
-    auto err = field_parse_binary(fv, detail::int2_oid, out_val);
+    auto err = field_parse(fv, detail::int2_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code());
@@ -813,7 +816,7 @@ void test_field_parse_text_optional_null_success()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_text(fv, detail::int4_oid, out_val);
+    auto err = field_parse(fv, detail::int4_oid, protocol::format_code::text, out_val);
 
     // Assert: a NULL field yields an empty optional, rather than an error
     BOOST_TEST_EQ(err, std::error_code());
@@ -827,7 +830,7 @@ void test_field_parse_binary_optional_null_success()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_binary(fv, detail::int4_oid, out_val);
+    auto err = field_parse(fv, detail::int4_oid, protocol::format_code::binary, out_val);
 
     // Assert: a NULL field yields an empty optional, rather than an error
     BOOST_TEST_EQ(err, std::error_code());
@@ -843,7 +846,7 @@ void test_field_parse_text_optional_non_null_success()
     field_view fv{data};
 
     // Act
-    auto err = field_parse_text(fv, detail::int4_oid, out_val);
+    auto err = field_parse(fv, detail::int4_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code());
@@ -883,9 +886,125 @@ static_assert(!serializable_field<char>);
 static_assert(!serializable_field<float>);
 static_assert(!serializable_field<double>);
 static_assert(!serializable_field<std::vector<std::byte>>);
-static_assert(!serializable_field<std::optional<std::int32_t>>);
 
-// TODO: serialization tests
+// An optional is serializable if and only if its value type is
+static_assert(serializable_field<std::optional<std::int32_t>>);
+static_assert(serializable_field<std::optional<std::string>>);
+static_assert(serializable_field<std::optional<std::string_view>>);
+static_assert(!serializable_field<std::optional<bool>>);
+static_assert(!serializable_field<std::optional<unmapped_type>>);
+
+// An optional advertises the OID of its value type
+static_assert(field_serialize_oid<std::optional<std::int32_t>> == field_serialize_oid<std::int32_t>);
+static_assert(field_serialize_oid<std::optional<std::string>> == field_serialize_oid<std::string>);
+
+//
+// field_serialize (field_traits_base.hpp)
+//
+
+// Serializes value and checks the resulting bytes
+template <class T>
+void check_serialize(
+    const T& value,
+    protocol::format_code code,
+    std::initializer_list<unsigned char> expected,
+    std::source_location loc = std::source_location::current()
+)
+{
+    // Arrange. Pre-populate the buffer, to verify that we append rather than overwrite
+    static constexpr unsigned char prefix[] = {0xde, 0xad};
+    std::vector<unsigned char> to(std::begin(prefix), std::end(prefix));
+
+    // Act
+    auto err = field_serialize(value, code, to);
+
+    // Assert
+    BOOST_TEST_EQ(err, std::error_code());
+    std::vector<unsigned char> expected_buff(std::begin(prefix), std::end(prefix));
+    expected_buff.insert(expected_buff.end(), expected.begin(), expected.end());
+    test::test_range_eq(to, expected_buff, loc);
+}
+
+void test_field_serialize_int_text_success()
+{
+    check_serialize(std::int16_t(-32768), protocol::format_code::text, {'-', '3', '2', '7', '6', '8'});
+    check_serialize(std::int16_t(32767), protocol::format_code::text, {'3', '2', '7', '6', '7'});
+    check_serialize(std::int32_t(0), protocol::format_code::text, {'0'});
+    check_serialize(
+        std::int32_t(-2147483648),
+        protocol::format_code::text,
+        {'-', '2', '1', '4', '7', '4', '8', '3', '6', '4', '8'}
+    );
+    check_serialize(
+        (std::numeric_limits<std::int64_t>::max)(),
+        protocol::format_code::text,
+        {'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5', '8', '0', '7'}
+    );
+}
+
+void test_field_serialize_int_binary_success()
+{
+    // Big endian, using the type's own width
+    check_serialize(std::int16_t(42), protocol::format_code::binary, {0x00, 0x2a});
+    check_serialize(std::int16_t(-2), protocol::format_code::binary, {0xff, 0xfe});
+    check_serialize(std::int32_t(42), protocol::format_code::binary, {0x00, 0x00, 0x00, 0x2a});
+    check_serialize(
+        std::int64_t(42),
+        protocol::format_code::binary,
+        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a}
+    );
+    check_serialize(
+        (std::numeric_limits<std::int64_t>::min)(),
+        protocol::format_code::binary,
+        {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+    );
+}
+
+void test_field_serialize_string_success()
+{
+    // Strings are serialized identically in both formats: the raw bytes, unterminated
+    for (auto code : {protocol::format_code::text, protocol::format_code::binary})
+    {
+        check_serialize(std::string("abc"), code, {'a', 'b', 'c'});
+        check_serialize(std::string_view("abc"), code, {'a', 'b', 'c'});
+        check_serialize(std::string(), code, {});
+
+        // A string literal is a C array, which the traits accept without decaying it.
+        // The terminator is not part of the value
+        check_serialize("abc", code, {'a', 'b', 'c'});
+
+        // Embedded NULLs are preserved (no C-string semantics)
+        check_serialize(std::string("a\0b", 3), code, {'a', 0x00, 'b'});
+    }
+}
+
+//
+// Nullable serialization (field_traits_nullable.hpp)
+//
+void test_field_serialize_optional_engaged_success()
+{
+    // An engaged optional produces exactly what the underlying value would
+    check_serialize(std::optional<std::int32_t>(42), protocol::format_code::text, {'4', '2'});
+    check_serialize(std::optional<std::int32_t>(42), protocol::format_code::binary, {0x00, 0x00, 0x00, 0x2a});
+    check_serialize(std::optional<std::string>("abc"), protocol::format_code::text, {'a', 'b', 'c'});
+}
+
+void test_field_serialize_optional_null()
+{
+    for (auto code : {protocol::format_code::text, protocol::format_code::binary})
+    {
+        // Arrange
+        std::optional<std::int32_t> value;
+        std::vector<unsigned char> to{0xde, 0xad};
+
+        // Act
+        auto err = field_serialize(value, code, to);
+
+        // Assert: the sentinel is reported, and nothing is appended
+        BOOST_TEST_EQ(err, error_code(client_errc::serialize_null));
+        BOOST_TEST_EQ(to.size(), 2u);
+    }
+}
 
 }  // namespace
 
@@ -993,7 +1112,7 @@ int main()
     test_parse_text_text_success<std::string>("The quick brown fox jumps over the lazy dog!");
     test_parse_binary_text_success<std::string>("The quick brown fox jumps over the lazy dog!");
 
-    // field_is_compatible / field_parse_text / field_parse_binary
+    // field_is_compatible / field_parse
     test_field_is_compatible_bool_success();
     test_field_is_compatible_bool_incompatible_error();
     test_field_is_compatible_int_widening_success();
@@ -1017,6 +1136,13 @@ int main()
     test_field_parse_text_optional_null_success();
     test_field_parse_binary_optional_null_success();
     test_field_parse_text_optional_non_null_success();
+
+    // field_serialize
+    test_field_serialize_int_text_success();
+    test_field_serialize_int_binary_success();
+    test_field_serialize_string_success();
+    test_field_serialize_optional_engaged_success();
+    test_field_serialize_optional_null();
 
     return boost::report_errors();
 }

--- a/test/unit/types/test_decimal.cpp
+++ b/test/unit/types/test_decimal.cpp
@@ -126,7 +126,7 @@ void test_parse_binary_decimal_error(std::span<const unsigned char> wire, std::e
 }
 
 //
-// field_is_compatible / field_parse_text / field_parse_binary (field_traits_decimal.hpp)
+// field_is_compatible / field_parse (field_traits_decimal.hpp)
 //
 void test_field_is_compatible_decimal_success()
 {
@@ -148,7 +148,7 @@ void test_field_parse_text_decimal_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_text(fv, detail::decimal_oid, out_val);
+    auto err = field_parse(fv, detail::decimal_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code(client_errc::unexpected_null));
@@ -161,7 +161,7 @@ void test_field_parse_binary_decimal_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_binary(fv, detail::decimal_oid, out_val);
+    auto err = field_parse(fv, detail::decimal_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code(client_errc::unexpected_null));
@@ -176,7 +176,7 @@ void test_field_parse_text_decimal_success()
     field_view fv{data};
 
     // Act
-    auto err = field_parse_text(fv, detail::decimal_oid, out_val);
+    auto err = field_parse(fv, detail::decimal_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code{});
@@ -193,7 +193,7 @@ void test_field_parse_binary_decimal_success()
     field_view fv{pg_num_1234_5678};
 
     // Act
-    auto err = field_parse_binary(fv, detail::decimal_oid, out_val);
+    auto err = field_parse(fv, detail::decimal_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code{});
@@ -305,7 +305,7 @@ int main()
     test_parse_binary_decimal_error<d32>(pg_too_short, parse_error);
     test_parse_binary_decimal_error<d32>(pg_truncated, parse_error);
 
-    // field_is_compatible / field_parse_text / field_parse_binary (field_traits_decimal.hpp)
+    // field_is_compatible / field_parse (field_traits_decimal.hpp)
     test_field_is_compatible_decimal_success();
     test_field_is_compatible_decimal_incompatible_error();
     test_field_parse_text_decimal_unexpected_null_error();

--- a/test/unit/types/test_json.cpp
+++ b/test/unit/types/test_json.cpp
@@ -183,7 +183,7 @@ void test_parse_binary_jsonb_version_only_is_noop()
 }
 
 //
-// field_is_compatible / field_parse_text / field_parse_binary (field_traits_json.hpp)
+// field_is_compatible / field_parse (field_traits_json.hpp)
 //
 void test_field_is_compatible_json_success()
 {
@@ -210,7 +210,7 @@ void test_field_parse_text_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_text(fv, detail::json_oid, out_val);
+    auto err = field_parse(fv, detail::json_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code(client_errc::unexpected_null));
@@ -223,7 +223,7 @@ void test_field_parse_binary_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_binary(fv, detail::jsonb_oid, out_val);
+    auto err = field_parse(fv, detail::jsonb_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code(client_errc::unexpected_null));
@@ -237,7 +237,7 @@ void test_field_parse_text_json_success()
     const auto fv = make_field_view(str);
 
     // Act
-    auto err = field_parse_text(fv, detail::json_oid, out_val);
+    auto err = field_parse(fv, detail::json_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code{});
@@ -252,7 +252,7 @@ void test_field_parse_binary_json_success()
     const auto fv = make_field_view(str);
 
     // Act
-    auto err = field_parse_binary(fv, detail::json_oid, out_val);
+    auto err = field_parse(fv, detail::json_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code{});
@@ -267,7 +267,7 @@ void test_field_parse_text_jsonb_success()
     const auto fv = make_field_view(str);
 
     // Act
-    auto err = field_parse_text(fv, detail::jsonb_oid, out_val);
+    auto err = field_parse(fv, detail::jsonb_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code{});
@@ -285,7 +285,7 @@ void test_field_parse_binary_jsonb_success()
     const auto fv = make_field_view(wire);
 
     // Act
-    auto err = field_parse_binary(fv, detail::jsonb_oid, out_val);
+    auto err = field_parse(fv, detail::jsonb_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code{});

--- a/test/unit/types/test_numeric.cpp
+++ b/test/unit/types/test_numeric.cpp
@@ -117,7 +117,7 @@ void test_parse_binary_numeric_digits_fit(std::span<const unsigned char> wire, s
 }
 
 //
-// field_is_compatible / field_parse_text / field_parse_binary (field_traits_numeric.hpp)
+// field_is_compatible / field_parse (field_traits_numeric.hpp)
 //
 void test_field_is_compatible_numeric_success()
 {
@@ -142,7 +142,7 @@ void test_field_parse_text_numeric_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_text(fv, detail::numeric_oid, out_val);
+    auto err = field_parse(fv, detail::numeric_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code(client_errc::unexpected_null));
@@ -155,7 +155,7 @@ void test_field_parse_binary_numeric_unexpected_null_error()
     field_view fv;  // NULL
 
     // Act
-    auto err = field_parse_binary(fv, detail::numeric_oid, out_val);
+    auto err = field_parse(fv, detail::numeric_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code(client_errc::unexpected_null));
@@ -170,7 +170,7 @@ void test_field_parse_text_numeric_success()
     field_view fv{data};
 
     // Act
-    auto err = field_parse_text(fv, detail::numeric_oid, out_val);
+    auto err = field_parse(fv, detail::numeric_oid, protocol::format_code::text, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code());
@@ -187,7 +187,7 @@ void test_field_parse_binary_numeric_success()
     field_view fv{pg_num_1234_5678};
 
     // Act
-    auto err = field_parse_binary(fv, detail::numeric_oid, out_val);
+    auto err = field_parse(fv, detail::numeric_oid, protocol::format_code::binary, out_val);
 
     // Assert
     BOOST_TEST_EQ(err, std::error_code());
@@ -320,7 +320,7 @@ int main()
     test_parse_binary_numeric_digits_fit<50>(pg_too_short, parse_error);
     test_parse_binary_numeric_digits_fit<50>(pg_truncated, parse_error);
 
-    // field_is_compatible / field_parse_text / field_parse_binary (field_traits_numeric.hpp)
+    // field_is_compatible / field_parse (field_traits_numeric.hpp)
     test_field_is_compatible_numeric_success();
     test_field_is_compatible_numeric_incompatible_error();
     test_field_parse_text_numeric_unexpected_null_error();


### PR DESCRIPTION
Coalesces parse_field_traits::{parse_text, parse_binary} back into parse_field_traits::parse
Coalesces serialize_field_traits::{serialize_text, serialize_binary} into serialize_field_traits::serialize
Adds client_errc::serialize_null
Changes serializable_ref to represent NULL as a function returning client_errc::serialize_null, rather than an empty optional
Implements serialization support for std::optional<T>

close #63 