### PR TITLE
Converts read_response_fsm::result into a plain std::error_code

### DIFF
--- a/include/nativepg/protocol/detail/exec_some_fsm.hpp
+++ b/include/nativepg/protocol/detail/exec_some_fsm.hpp
@@ -11,9 +11,9 @@
 #include <boost/assert.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
-#include <system_error>
 
 #include <cstddef>
+#include <system_error>
 #include <vector>
 
 #include "coroutine.hpp"
@@ -127,11 +127,10 @@ public:
                     // Check if the message is legal in our state,
                     // and if it ends the sequence we're looking for.
                     // Copy messages are never the last one, so this is safe
-                    if (auto read_res = fsm_.resume(res.message);
-                        read_res.type == protocol::read_response_fsm::result_type::done)
+                    if (auto read_ec = fsm_.resume(res.message); read_ec != client_errc::needs_more)
                     {
                         st.read_buffer.consume(consumed_);
-                        return {read_res.ec};
+                        return {read_ec};
                     }
 
                     // React to copy messages

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -42,21 +42,6 @@ struct read_response_fsm_impl
 class read_response_fsm
 {
 public:
-    enum class result_type
-    {
-        done,
-        read,
-    };
-
-    struct result
-    {
-        result_type type;
-        std::error_code ec;
-
-        result(std::error_code ec) noexcept : type(result_type::done), ec(ec) {}
-        result(result_type t) noexcept : type(t) {}
-    };
-
     read_response_fsm(const request* req, response_handler_ref handler, bool allow_copy = false) noexcept
         : impl_{req, handler, allow_copy}
     {
@@ -71,7 +56,10 @@ public:
         return impl_.req->messages().subspan(impl_.current);
     }
 
-    result resume(const any_backend_message& msg);
+    // Feeds a message to the FSM. Returns client_errc::needs_more if more messages
+    // are required to complete the response, a success code if the response is
+    // complete, or any other error code on failure
+    std::error_code resume(const any_backend_message& msg);
 
 private:
     detail::read_response_fsm_impl impl_;

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -9,17 +9,35 @@
 #define NATIVEPG_PROTOCOL_READ_RESPONSE_FSM_HPP
 
 #include <boost/compat/function_ref.hpp>
-#include <system_error>
 
 #include <cstddef>
 #include <span>
+#include <system_error>
 
 #include "nativepg/protocol/any_backend_message.hpp"
-#include "nativepg/protocol/notice_error.hpp"
 #include "nativepg/request.hpp"
 #include "nativepg/responses/response_handler.hpp"
 
 namespace nativepg::protocol {
+
+namespace detail {
+
+// Split here so we don't need to declare private functions in this header
+struct read_response_fsm_impl
+{
+    enum class state_t;
+
+    // Params
+    const request* req;
+    response_handler_ref handler;
+    bool allow_copy;
+
+    // Working state
+    std::size_t current{};
+    state_t state{static_cast<state_t>(0)};
+};
+
+}  // namespace detail
 
 class read_response_fsm
 {
@@ -40,40 +58,23 @@ public:
     };
 
     read_response_fsm(const request* req, response_handler_ref handler, bool allow_copy = false) noexcept
-        : req_(req), handler_(handler), allow_copy_(allow_copy)
+        : impl_{req, handler, allow_copy}
     {
         BOOST_ASSERT(req != nullptr);
     }
 
-    const request& get_request() const { return *req_; }
-    response_handler_ref get_handler() const { return handler_; }
+    const request& get_request() const { return *impl_.req; }
+    response_handler_ref get_handler() const { return impl_.handler; }
 
     std::span<const request_message_type> get_remaining_messages() const
     {
-        return req_->messages().subspan(current_);
+        return impl_.req->messages().subspan(impl_.current);
     }
 
     result resume(const any_backend_message& msg);
 
 private:
-    enum class state_t;
-
-    const request* req_;
-    response_handler_ref handler_;
-    std::size_t current_{};
-    state_t state_{static_cast<state_t>(0)};
-    bool allow_copy_;
-
-    inline void call_handler(const any_request_message& msg) { handler_.on_message(msg, current_); }
-    result advance();
-    result handle_bind(const any_backend_message&);
-    result handle_close(const any_backend_message&);
-    result handle_describe(const any_backend_message&);
-    result handle_execute(const any_backend_message&);
-    result handle_parse(const any_backend_message&);
-    result handle_sync(const any_backend_message&);
-    result handle_query(const any_backend_message&);
-    result handle_error(const error_response& err);
+    detail::read_response_fsm_impl impl_;
 };
 
 }  // namespace nativepg::protocol

--- a/include/nativepg/protocol/read_response_fsm.hpp
+++ b/include/nativepg/protocol/read_response_fsm.hpp
@@ -8,8 +8,6 @@
 #ifndef NATIVEPG_PROTOCOL_READ_RESPONSE_FSM_HPP
 #define NATIVEPG_PROTOCOL_READ_RESPONSE_FSM_HPP
 
-#include <boost/compat/function_ref.hpp>
-
 #include <cstddef>
 #include <span>
 #include <system_error>

--- a/src/exec_fsm.cpp
+++ b/src/exec_fsm.cpp
@@ -25,7 +25,7 @@ using nativepg::client_errc;
 
 exec_fsm::result exec_fsm::resume(connection_state& st, std::error_code ec, std::size_t bytes_transferred)
 {
-    read_response_fsm::result res{{}};
+    std::error_code res;
     parse_message_result msg_res;
 
     switch (resume_point_)
@@ -51,8 +51,8 @@ exec_fsm::result exec_fsm::resume(connection_state& st, std::error_code ec, std:
                 // We have a message
                 res = read_fsm_.resume(msg_res.message);
                 st.read_buffer.consume(msg_res.size);
-                if (res.type == read_response_fsm::result_type::done)
-                    return res.ec;
+                if (res != client_errc::needs_more)
+                    return res;
             }
             else if (msg_res.ec == client_errc::needs_more)
             {

--- a/src/nativepg_internal/multiplexed_connection/multiplexer.hpp
+++ b/src/nativepg_internal/multiplexed_connection/multiplexer.hpp
@@ -81,8 +81,6 @@ public:
     [[nodiscard]]
     std::error_code on_message(std::deque<multiplexer_elem>& elms, const protocol::any_backend_message& msg)
     {
-        using protocol::read_response_fsm;
-
         if (status_ == status::initial)
         {
             // We're starting a new message. Ignore any abandoned
@@ -118,16 +116,17 @@ public:
                 // Handle the message
                 auto res = fsm_->resume(msg);
 
-                // If the FSM terminates, it means we're done with this request
-                if (res.type == read_response_fsm::result_type::done)
-                {
-                    elms.front().on_done(res.ec);
-                    elms.pop_front();
-                    status_ = status::initial;
-                }
+                // The FSM needs further messages to complete this request
+                if (res == client_errc::needs_more)
+                    return {};
+
+                // The FSM terminated, so we're done with this request
+                elms.front().on_done(res);
+                elms.pop_front();
+                status_ = status::initial;
 
                 // Any errors here are protocol violations and should cause connection teardown
-                return res.ec;
+                return res;
             }
             case status::ignoring:
             {

--- a/src/read_response_fsm.cpp
+++ b/src/read_response_fsm.cpp
@@ -14,11 +14,15 @@
 #include "nativepg/request.hpp"
 #include "nativepg/responses/response_handler.hpp"
 
-using namespace nativepg::protocol;
-using nativepg::client_errc;
-using kind = any_backend_message::kind;
+using namespace nativepg;
+using protocol::any_backend_message;
+using kind = protocol::any_backend_message::kind;
+using protocol::detail::read_response_fsm_impl;
+using state_t = read_response_fsm_impl::state_t;
+using result = protocol::read_response_fsm::result;
+using result_type = protocol::read_response_fsm::result_type;
 
-enum class read_response_fsm::state_t
+enum class read_response_fsm_impl::state_t
 {
     msg_first = 0,
     query_first,
@@ -30,23 +34,28 @@ enum class read_response_fsm::state_t
     query_copy_out_needs_command_complete,
 };
 
-read_response_fsm::result read_response_fsm::handle_error(const error_response& err)
+static void call_handler(read_response_fsm_impl& fsm, const any_request_message& msg)
+{
+    fsm.handler.on_message(msg, fsm.current);
+}
+
+static result handle_error(read_response_fsm_impl& fsm, const protocol::error_response& err)
 {
     // Call the handler with the error
-    call_handler(err);
-    ++current_;
-    state_ = state_t::msg_first;
+    call_handler(fsm, err);
+    ++fsm.current;
+    fsm.state = state_t::msg_first;
 
     // Skip subsequent messages until a sync is found
     // We should always find one because we check that this is the case
     // before sending the request
-    for (; current_ < req_->messages().size(); ++current_)
+    for (; fsm.current < fsm.req->messages().size(); ++fsm.current)
     {
-        switch (req_->messages()[current_])
+        switch (fsm.req->messages()[fsm.current])
         {
             case request_message_type::sync: return result(result_type::read);
             case request_message_type::flush: break;
-            default: call_handler(message_skipped{}); break;
+            default: call_handler(fsm, message_skipped{}); break;
         }
     }
 
@@ -54,83 +63,83 @@ read_response_fsm::result read_response_fsm::handle_error(const error_response& 
     return std::error_code(client_errc::request_ends_without_sync);
 }
 
-read_response_fsm::result read_response_fsm::advance()
+static result advance(read_response_fsm_impl& fsm)
 {
-    if (++current_ >= req_->messages().size())
+    if (++fsm.current >= fsm.req->messages().size())
         return std::error_code();
     else
         return result(result_type::read);
 }
 
-read_response_fsm::result read_response_fsm::handle_bind(const any_backend_message& msg)
+static result handle_bind(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // bind: either (bind_complete, error_response)
-    BOOST_ASSERT(state_ == state_t::msg_first);
+    BOOST_ASSERT(fsm.state == state_t::msg_first);
     switch (msg.type())
     {
         case kind::error_response:
             // An error finishes this message and makes the server skip everything until sync
-            return handle_error(msg.get_error_response());
+            return handle_error(fsm, msg.get_error_response());
         case kind::bind_complete:
             // Finishes the bind phase
-            call_handler(msg.get_bind_complete());
-            return advance();
+            call_handler(fsm, msg.get_bind_complete());
+            return advance(fsm);
         default: return std::error_code(client_errc::unexpected_message);
     }
 }
 
-read_response_fsm::result read_response_fsm::handle_close(const any_backend_message& msg)
+static result handle_close(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // close: either (close_complete, error_response)
-    BOOST_ASSERT(state_ == state_t::msg_first);
+    BOOST_ASSERT(fsm.state == state_t::msg_first);
     switch (msg.type())
     {
         case kind::error_response:
             // An error finishes this message and makes the server skip everything until sync
-            return handle_error(msg.get_error_response());
+            return handle_error(fsm, msg.get_error_response());
         case kind::close_complete:
             // Finishes the close phase
-            call_handler(msg.get_close_complete());
-            return advance();
+            call_handler(fsm, msg.get_close_complete());
+            return advance(fsm);
         default: return std::error_code(client_errc::unexpected_message);
     }
 }
 
 // TODO: we need to differentiate between describe statement and portal
 // only the portal version is supported now
-read_response_fsm::result read_response_fsm::handle_describe(const any_backend_message& msg)
+static result handle_describe(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // describe (portal)
     //   either: row_description, no_data, error_response
     // describe (statement) TODO: support this. Either
     //   parameter_description, then either (row_description, no_data)
     //   error_response
-    BOOST_ASSERT(state_ == state_t::msg_first);
+    BOOST_ASSERT(fsm.state == state_t::msg_first);
     switch (msg.type())
     {
         case kind::error_response:
             // An error finishes this message and makes the server skip everything until sync
-            return handle_error(msg.get_error_response());
+            return handle_error(fsm, msg.get_error_response());
         case kind::row_description:
             // Finishes the describe phase
-            call_handler(msg.get_row_description());
-            return advance();
+            call_handler(fsm, msg.get_row_description());
+            return advance(fsm);
         case kind::no_data:
             // We transform no_data into an empty row description, for uniformity.
             // Finishes the describe phase.
-            call_handler(row_description{});
-            return advance();
+            call_handler(fsm, protocol::row_description{});
+            return advance(fsm);
         default: return std::error_code(client_errc::unexpected_message);
     }
 }
 
-read_response_fsm::result read_response_fsm::handle_execute(const any_backend_message& msg)
+static result handle_execute(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // execute: either:
     //   copy_out_response, then any number of copy_data, then copy_done, then either (command_complete,
     //   error_response) any number of data_row, then either (command_complete, portal_suspended,
     //   error_response) empty_query_response
-    switch (state_)
+    switch (fsm.state)
     {
         case state_t::msg_first:
         {
@@ -140,29 +149,29 @@ read_response_fsm::result read_response_fsm::handle_execute(const any_backend_me
                     // Starts a COPY OUT block.
                     // Data is handled by the upper layers as a separate channel.
                     // The handler sees an empty resultset.
-                    if (!allow_copy_)
+                    if (!fsm.allow_copy)
                         return std::error_code(client_errc::copy_not_allowed);
-                    call_handler(row_description{});
-                    state_ = state_t::exec_copy_out;
+                    call_handler(fsm, protocol::row_description{});
+                    fsm.state = state_t::exec_copy_out;
                     return result_type::read;
                 case kind::error_response:
                     // An error finishes this message and makes the server skip everything until sync
-                    return handle_error(msg.get_error_response());
+                    return handle_error(fsm, msg.get_error_response());
                 case kind::command_complete:
                     // Finishes the execution phase
-                    call_handler(msg.get_command_complete());
-                    return advance();
+                    call_handler(fsm, msg.get_command_complete());
+                    return advance(fsm);
                 case kind::empty_query_response:
                     // Finishes the execution phase
-                    call_handler(msg.get_empty_query_response());
-                    return advance();
+                    call_handler(fsm, msg.get_empty_query_response());
+                    return advance(fsm);
                 case kind::portal_suspended:
                     // Finishes the execution phase
-                    call_handler(msg.get_portal_suspended());
-                    return advance();
+                    call_handler(fsm, msg.get_portal_suspended());
+                    return advance(fsm);
                 case kind::data_row:
                     // We got a row. This doesn't change state
-                    call_handler(msg.get_data_row());
+                    call_handler(fsm, msg.get_data_row());
                     return result_type::read;
                 default: return std::error_code(client_errc::unexpected_message);
             }
@@ -176,10 +185,10 @@ read_response_fsm::result read_response_fsm::handle_execute(const any_backend_me
                     return result_type::read;
                 case kind::error_response:
                     // Terminates copy out
-                    return handle_error(msg.get_error_response());
+                    return handle_error(fsm, msg.get_error_response());
                 case kind::copy_done:
                     // Terminates copy out, but should be followed by CommandComplete
-                    state_ = state_t::exec_copy_out_needs_command_complete;
+                    fsm.state = state_t::exec_copy_out_needs_command_complete;
                     return result_type::read;
                 default: return std::error_code(client_errc::unexpected_message);
             }
@@ -190,11 +199,11 @@ read_response_fsm::result read_response_fsm::handle_execute(const any_backend_me
             {
                 case kind::error_response:
                     // This is possible, in theory
-                    return handle_error(msg.get_error_response());
+                    return handle_error(fsm, msg.get_error_response());
                 case kind::command_complete:
-                    call_handler(msg.get_command_complete());
-                    state_ = state_t::msg_first;
-                    return advance();
+                    call_handler(fsm, msg.get_command_complete());
+                    fsm.state = state_t::msg_first;
+                    return advance(fsm);
                 default: return std::error_code(client_errc::unexpected_message);
             }
         }
@@ -202,34 +211,34 @@ read_response_fsm::result read_response_fsm::handle_execute(const any_backend_me
     }
 }
 
-read_response_fsm::result read_response_fsm::handle_parse(const any_backend_message& msg)
+static result handle_parse(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // parse: either (parse_complete, error_response)
-    BOOST_ASSERT(state_ == state_t::msg_first);
+    BOOST_ASSERT(fsm.state == state_t::msg_first);
     switch (msg.type())
     {
         case kind::error_response:
             // An error finishes this message and makes the server skip everything until sync
-            return handle_error(msg.get_error_response());
+            return handle_error(fsm, msg.get_error_response());
         case kind::parse_complete:
             // Finishes the parse phase
-            call_handler(msg.get_parse_complete());
-            return advance();
+            call_handler(fsm, msg.get_parse_complete());
+            return advance(fsm);
         default: return std::error_code(client_errc::unexpected_message);
     }
 }
 
-read_response_fsm::result read_response_fsm::handle_sync(const any_backend_message& msg)
+static result handle_sync(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // sync always returns ReadyForQuery. Getting an error here is a protocol error,
     // as we don't know whether the connection is healthy or not
-    BOOST_ASSERT(state_ == state_t::msg_first);
+    BOOST_ASSERT(fsm.state == state_t::msg_first);
     if (msg.type() != kind::ready_for_query)
         return std::error_code(client_errc::unexpected_message);
-    return advance();
+    return advance(fsm);
 }
 
-read_response_fsm::result read_response_fsm::handle_query(const any_backend_message& msg)
+static result handle_query(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // either
     //    at least one
@@ -243,7 +252,7 @@ read_response_fsm::result read_response_fsm::handle_query(const any_backend_mess
     //            copy_done, followed by (command_complete or error_response), or error_response
     //    ready_for_query
     // or empty_query_response
-    switch (state_)
+    switch (fsm.state)
     {
         case state_t::msg_first:
         case state_t::query_first:
@@ -254,43 +263,43 @@ read_response_fsm::result read_response_fsm::handle_query(const any_backend_mess
                     // Starts a COPY OUT block.
                     // Data is handled by the upper layers as a separate channel.
                     // The handler sees an empty resultset.
-                    if (!allow_copy_)
+                    if (!fsm.allow_copy)
                         return std::error_code(client_errc::copy_not_allowed);
-                    call_handler(row_description{});
-                    state_ = state_t::query_copy_out;
+                    call_handler(fsm, protocol::row_description{});
+                    fsm.state = state_t::query_copy_out;
                     return result_type::read;
                 case kind::error_response:
                     // An error should always be followed by ReadyForQuery
-                    state_ = state_t::query_needs_ready;
-                    call_handler(msg.get_error_response());
+                    fsm.state = state_t::query_needs_ready;
+                    call_handler(fsm, msg.get_error_response());
                     return result_type::read;
                 case kind::row_description:
                     // Row descriptions are optional, and can only appear at the beginning of
                     // a resultset, but should always precede rows
-                    state_ = state_t::query_rows;
-                    call_handler(msg.get_row_description());
+                    fsm.state = state_t::query_rows;
+                    call_handler(fsm, msg.get_row_description());
                     return result_type::read;
                 case kind::command_complete:
                     // Query might return command_complete directly, without NoData.
                     // Synthesize a fake row_description to help handlers
-                    state_ = state_t::query_first;
-                    call_handler(row_description{});
-                    call_handler(msg.get_command_complete());
+                    fsm.state = state_t::query_first;
+                    call_handler(fsm, protocol::row_description{});
+                    call_handler(fsm, msg.get_command_complete());
                     return result_type::read;
                 case kind::empty_query_response:
                     // Only allowed as the first and only message. Signals that there was no query to begin
                     // with
-                    if (state_ != state_t::msg_first)
+                    if (fsm.state != state_t::msg_first)
                         return std::error_code(client_errc::unexpected_message);
-                    state_ = state_t::query_needs_ready;
-                    call_handler(msg.get_empty_query_response());
+                    fsm.state = state_t::query_needs_ready;
+                    call_handler(fsm, msg.get_empty_query_response());
                     return result_type::read;
                 case kind::ready_for_query:
-                    if (state_ != state_t::query_first)
+                    if (fsm.state != state_t::query_first)
                         return std::error_code(client_errc::unexpected_message);
                     // Not allowed as the only response to a query
-                    state_ = state_t::msg_first;
-                    return advance();
+                    fsm.state = state_t::msg_first;
+                    return advance(fsm);
                 default: return std::error_code(client_errc::unexpected_message);
             }
         }
@@ -300,17 +309,17 @@ read_response_fsm::result read_response_fsm::handle_query(const any_backend_mess
             {
                 case kind::error_response:
                     // An error should always be followed by ReadyForQuery
-                    state_ = state_t::query_needs_ready;
-                    call_handler(msg.get_error_response());
+                    fsm.state = state_t::query_needs_ready;
+                    call_handler(fsm, msg.get_error_response());
                     return result_type::read;
                 case kind::data_row:
                     // We got a row. This doesn't change state
-                    call_handler(msg.get_data_row());
+                    call_handler(fsm, msg.get_data_row());
                     return result_type::read;
                 case kind::command_complete:
                     // This resultset is done
-                    state_ = state_t::query_first;
-                    call_handler(msg.get_command_complete());
+                    fsm.state = state_t::query_first;
+                    call_handler(fsm, msg.get_command_complete());
                     return result_type::read;
                 default: return std::error_code(client_errc::unexpected_message);
             }
@@ -320,8 +329,8 @@ read_response_fsm::result read_response_fsm::handle_query(const any_backend_mess
             if (msg.type() == kind::ready_for_query)
             {
                 // We're done with the current message
-                state_ = state_t::msg_first;
-                return advance();
+                fsm.state = state_t::msg_first;
+                return advance(fsm);
             }
             return std::error_code(client_errc::unexpected_message);
         case state_t::query_copy_out:
@@ -333,12 +342,12 @@ read_response_fsm::result read_response_fsm::handle_query(const any_backend_mess
                     return result_type::read;
                 case kind::error_response:
                     // An error should always be followed by ReadyForQuery
-                    state_ = state_t::query_needs_ready;
-                    call_handler(msg.get_error_response());
+                    fsm.state = state_t::query_needs_ready;
+                    call_handler(fsm, msg.get_error_response());
                     return result_type::read;
                 case kind::copy_done:
                     // Terminates copy out, but should be followed by CommandComplete
-                    state_ = state_t::query_copy_out_needs_command_complete;
+                    fsm.state = state_t::query_copy_out_needs_command_complete;
                     return result_type::read;
                 default: return std::error_code(client_errc::unexpected_message);
             }
@@ -349,12 +358,12 @@ read_response_fsm::result read_response_fsm::handle_query(const any_backend_mess
             {
                 case kind::error_response:
                     // An error should always be followed by ReadyForQuery
-                    state_ = state_t::query_needs_ready;
-                    call_handler(msg.get_error_response());
+                    fsm.state = state_t::query_needs_ready;
+                    call_handler(fsm, msg.get_error_response());
                     return result_type::read;
                 case kind::command_complete:
-                    call_handler(msg.get_command_complete());
-                    state_ = state_t::query_first;
+                    call_handler(fsm, msg.get_command_complete());
+                    fsm.state = state_t::query_first;
                     return result_type::read;
                 default: return std::error_code(client_errc::unexpected_message);
             }
@@ -363,7 +372,7 @@ read_response_fsm::result read_response_fsm::handle_query(const any_backend_mess
     }
 }
 
-read_response_fsm::result read_response_fsm::resume(const any_backend_message& msg)
+result protocol::read_response_fsm::resume(const any_backend_message& msg)
 {
     // Some messages may be found interleaved with the expected message flow
     // TODO: actually do something useful with these
@@ -378,20 +387,20 @@ read_response_fsm::result read_response_fsm::resume(const any_backend_message& m
     // The allowed messages depend on the current type
     while (true)
     {
-        switch (req_->messages()[current_])
+        switch (impl_.req->messages()[impl_.current])
         {
-            case request_message_type::bind: return handle_bind(msg);
-            case request_message_type::close: return handle_close(msg);
-            case request_message_type::describe: return handle_describe(msg);
-            case request_message_type::execute: return handle_execute(msg);
+            case request_message_type::bind: return handle_bind(impl_, msg);
+            case request_message_type::close: return handle_close(impl_, msg);
+            case request_message_type::describe: return handle_describe(impl_, msg);
+            case request_message_type::execute: return handle_execute(impl_, msg);
             case request_message_type::flush:
             {
-                ++current_;
+                ++impl_.current;
                 continue;  // nothing is expected here
             }
-            case request_message_type::parse: return handle_parse(msg);
-            case request_message_type::query: return handle_query(msg);
-            case request_message_type::sync: return handle_sync(msg);
+            case request_message_type::parse: return handle_parse(impl_, msg);
+            case request_message_type::query: return handle_query(impl_, msg);
+            case request_message_type::sync: return handle_sync(impl_, msg);
         }
     }
 }

--- a/src/read_response_fsm.cpp
+++ b/src/read_response_fsm.cpp
@@ -19,8 +19,6 @@ using protocol::any_backend_message;
 using kind = protocol::any_backend_message::kind;
 using protocol::detail::read_response_fsm_impl;
 using state_t = read_response_fsm_impl::state_t;
-using result = protocol::read_response_fsm::result;
-using result_type = protocol::read_response_fsm::result_type;
 
 enum class read_response_fsm_impl::state_t
 {
@@ -39,7 +37,7 @@ static void call_handler(read_response_fsm_impl& fsm, const any_request_message&
     fsm.handler.on_message(msg, fsm.current);
 }
 
-static result handle_error(read_response_fsm_impl& fsm, const protocol::error_response& err)
+static std::error_code handle_error(read_response_fsm_impl& fsm, const protocol::error_response& err)
 {
     // Call the handler with the error
     call_handler(fsm, err);
@@ -53,7 +51,7 @@ static result handle_error(read_response_fsm_impl& fsm, const protocol::error_re
     {
         switch (fsm.req->messages()[fsm.current])
         {
-            case request_message_type::sync: return result(result_type::read);
+            case request_message_type::sync: return client_errc::needs_more;
             case request_message_type::flush: break;
             default: call_handler(fsm, message_skipped{}); break;
         }
@@ -63,15 +61,15 @@ static result handle_error(read_response_fsm_impl& fsm, const protocol::error_re
     return std::error_code(client_errc::request_ends_without_sync);
 }
 
-static result advance(read_response_fsm_impl& fsm)
+static std::error_code advance(read_response_fsm_impl& fsm)
 {
     if (++fsm.current >= fsm.req->messages().size())
         return std::error_code();
     else
-        return result(result_type::read);
+        return client_errc::needs_more;
 }
 
-static result handle_bind(read_response_fsm_impl& fsm, const any_backend_message& msg)
+static std::error_code handle_bind(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // bind: either (bind_complete, error_response)
     BOOST_ASSERT(fsm.state == state_t::msg_first);
@@ -88,7 +86,7 @@ static result handle_bind(read_response_fsm_impl& fsm, const any_backend_message
     }
 }
 
-static result handle_close(read_response_fsm_impl& fsm, const any_backend_message& msg)
+static std::error_code handle_close(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // close: either (close_complete, error_response)
     BOOST_ASSERT(fsm.state == state_t::msg_first);
@@ -107,7 +105,7 @@ static result handle_close(read_response_fsm_impl& fsm, const any_backend_messag
 
 // TODO: we need to differentiate between describe statement and portal
 // only the portal version is supported now
-static result handle_describe(read_response_fsm_impl& fsm, const any_backend_message& msg)
+static std::error_code handle_describe(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // describe (portal)
     //   either: row_description, no_data, error_response
@@ -133,7 +131,7 @@ static result handle_describe(read_response_fsm_impl& fsm, const any_backend_mes
     }
 }
 
-static result handle_execute(read_response_fsm_impl& fsm, const any_backend_message& msg)
+static std::error_code handle_execute(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // execute: either:
     //   copy_out_response, then any number of copy_data, then copy_done, then either (command_complete,
@@ -153,7 +151,7 @@ static result handle_execute(read_response_fsm_impl& fsm, const any_backend_mess
                         return std::error_code(client_errc::copy_not_allowed);
                     call_handler(fsm, protocol::row_description{});
                     fsm.state = state_t::exec_copy_out;
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::error_response:
                     // An error finishes this message and makes the server skip everything until sync
                     return handle_error(fsm, msg.get_error_response());
@@ -172,7 +170,7 @@ static result handle_execute(read_response_fsm_impl& fsm, const any_backend_mess
                 case kind::data_row:
                     // We got a row. This doesn't change state
                     call_handler(fsm, msg.get_data_row());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 default: return std::error_code(client_errc::unexpected_message);
             }
         }
@@ -182,14 +180,14 @@ static result handle_execute(read_response_fsm_impl& fsm, const any_backend_mess
             {
                 case kind::copy_data:
                     // Data is handled by upper layers, we don't need to do anything
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::error_response:
                     // Terminates copy out
                     return handle_error(fsm, msg.get_error_response());
                 case kind::copy_done:
                     // Terminates copy out, but should be followed by CommandComplete
                     fsm.state = state_t::exec_copy_out_needs_command_complete;
-                    return result_type::read;
+                    return client_errc::needs_more;
                 default: return std::error_code(client_errc::unexpected_message);
             }
         }
@@ -211,7 +209,7 @@ static result handle_execute(read_response_fsm_impl& fsm, const any_backend_mess
     }
 }
 
-static result handle_parse(read_response_fsm_impl& fsm, const any_backend_message& msg)
+static std::error_code handle_parse(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // parse: either (parse_complete, error_response)
     BOOST_ASSERT(fsm.state == state_t::msg_first);
@@ -228,7 +226,7 @@ static result handle_parse(read_response_fsm_impl& fsm, const any_backend_messag
     }
 }
 
-static result handle_sync(read_response_fsm_impl& fsm, const any_backend_message& msg)
+static std::error_code handle_sync(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // sync always returns ReadyForQuery. Getting an error here is a protocol error,
     // as we don't know whether the connection is healthy or not
@@ -238,7 +236,7 @@ static result handle_sync(read_response_fsm_impl& fsm, const any_backend_message
     return advance(fsm);
 }
 
-static result handle_query(read_response_fsm_impl& fsm, const any_backend_message& msg)
+static std::error_code handle_query(read_response_fsm_impl& fsm, const any_backend_message& msg)
 {
     // either
     //    at least one
@@ -267,25 +265,25 @@ static result handle_query(read_response_fsm_impl& fsm, const any_backend_messag
                         return std::error_code(client_errc::copy_not_allowed);
                     call_handler(fsm, protocol::row_description{});
                     fsm.state = state_t::query_copy_out;
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::error_response:
                     // An error should always be followed by ReadyForQuery
                     fsm.state = state_t::query_needs_ready;
                     call_handler(fsm, msg.get_error_response());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::row_description:
                     // Row descriptions are optional, and can only appear at the beginning of
                     // a resultset, but should always precede rows
                     fsm.state = state_t::query_rows;
                     call_handler(fsm, msg.get_row_description());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::command_complete:
                     // Query might return command_complete directly, without NoData.
                     // Synthesize a fake row_description to help handlers
                     fsm.state = state_t::query_first;
                     call_handler(fsm, protocol::row_description{});
                     call_handler(fsm, msg.get_command_complete());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::empty_query_response:
                     // Only allowed as the first and only message. Signals that there was no query to begin
                     // with
@@ -293,7 +291,7 @@ static result handle_query(read_response_fsm_impl& fsm, const any_backend_messag
                         return std::error_code(client_errc::unexpected_message);
                     fsm.state = state_t::query_needs_ready;
                     call_handler(fsm, msg.get_empty_query_response());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::ready_for_query:
                     if (fsm.state != state_t::query_first)
                         return std::error_code(client_errc::unexpected_message);
@@ -311,16 +309,16 @@ static result handle_query(read_response_fsm_impl& fsm, const any_backend_messag
                     // An error should always be followed by ReadyForQuery
                     fsm.state = state_t::query_needs_ready;
                     call_handler(fsm, msg.get_error_response());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::data_row:
                     // We got a row. This doesn't change state
                     call_handler(fsm, msg.get_data_row());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::command_complete:
                     // This resultset is done
                     fsm.state = state_t::query_first;
                     call_handler(fsm, msg.get_command_complete());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 default: return std::error_code(client_errc::unexpected_message);
             }
         }
@@ -339,16 +337,16 @@ static result handle_query(read_response_fsm_impl& fsm, const any_backend_messag
             {
                 case kind::copy_data:
                     // Data is handled by upper layers, we don't need to do anything
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::error_response:
                     // An error should always be followed by ReadyForQuery
                     fsm.state = state_t::query_needs_ready;
                     call_handler(fsm, msg.get_error_response());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::copy_done:
                     // Terminates copy out, but should be followed by CommandComplete
                     fsm.state = state_t::query_copy_out_needs_command_complete;
-                    return result_type::read;
+                    return client_errc::needs_more;
                 default: return std::error_code(client_errc::unexpected_message);
             }
         }
@@ -360,11 +358,11 @@ static result handle_query(read_response_fsm_impl& fsm, const any_backend_messag
                     // An error should always be followed by ReadyForQuery
                     fsm.state = state_t::query_needs_ready;
                     call_handler(fsm, msg.get_error_response());
-                    return result_type::read;
+                    return client_errc::needs_more;
                 case kind::command_complete:
                     call_handler(fsm, msg.get_command_complete());
                     fsm.state = state_t::query_first;
-                    return result_type::read;
+                    return client_errc::needs_more;
                 default: return std::error_code(client_errc::unexpected_message);
             }
         }
@@ -372,7 +370,7 @@ static result handle_query(read_response_fsm_impl& fsm, const any_backend_messag
     }
 }
 
-result protocol::read_response_fsm::resume(const any_backend_message& msg)
+std::error_code protocol::read_response_fsm::resume(const any_backend_message& msg)
 {
     // Some messages may be found interleaved with the expected message flow
     // TODO: actually do something useful with these
@@ -380,7 +378,7 @@ result protocol::read_response_fsm::resume(const any_backend_message& msg)
     {
         case kind::notice_response:
         case kind::notification_response:
-        case kind::parameter_status: return result_type::read;
+        case kind::parameter_status: return client_errc::needs_more;
         default: break;
     }
 

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -16,6 +16,7 @@
 #include <system_error>
 #include <vector>
 
+#include "nativepg/client_errc.hpp"
 #include "nativepg/extended_error.hpp"
 #include "nativepg/protocol/async.hpp"
 #include "nativepg/protocol/bind.hpp"
@@ -38,37 +39,10 @@ using namespace nativepg;
 using namespace nativepg::test;
 using protocol::read_response_fsm;
 using std::error_code;
-using result_type = read_response_fsm::result_type;
-
-// Operators
-static const char* to_string(result_type t)
-{
-    switch (t)
-    {
-        case result_type::done: return "done";
-        case result_type::read: return "read";
-        default: return "<unknown result_type>";
-    }
-}
-
-namespace nativepg::protocol {
-
-bool operator==(const read_response_fsm::result& lhs, const read_response_fsm::result& rhs)
-{
-    return lhs.type == rhs.type && lhs.ec == rhs.ec;
-}
-
-std::ostream& operator<<(std::ostream& os, const read_response_fsm::result& value)
-{
-    os << "read_response_fsm_impl::result{ .type=" << to_string(value.type);
-    if (value.type == result_type::done)
-        os << ", .ec=" << value.ec;
-    return os << " }";
-}
-
-}  // namespace nativepg::protocol
 
 namespace {
+
+const error_code needs_more{client_errc::needs_more};
 
 // A handler that just stores its arguments
 struct mock_handler
@@ -107,10 +81,10 @@ void test_simple_query()
     fix.req.add_simple_query("SELECT 1");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -129,8 +103,8 @@ void test_simple_query_no_rows()
     fix.req.add_simple_query("SELECT 1");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -148,7 +122,7 @@ void test_simple_query_no_data()
     fix.req.add_simple_query("SELECT 1");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -165,13 +139,13 @@ void test_simple_query_multi()
     fix.req.add_simple_query("SELECT 1");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -194,7 +168,7 @@ void test_simple_query_empty()
     fix.req.add_simple_query("");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::empty_query_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::empty_query_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -210,7 +184,7 @@ void test_simple_query_error()
     fix.req.add_simple_query("SELECT 1");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -226,9 +200,9 @@ void test_simple_query_error_skipping()
     fix.req.add_simple_query("SELECT 1").add_simple_query("SELECT 2");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -248,7 +222,7 @@ void test_parse()
     fix.req.add_prepare("SELECT 1", "mystmt");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -266,7 +240,7 @@ void test_parse_error()
     fix.req.add_prepare("SELECT 1", "mystmt").add_prepare("SELECT 2", "stmt").add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -283,7 +257,7 @@ void test_bind()
     fix.req.add(protocol::bind{}).add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::bind_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::bind_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -299,7 +273,7 @@ void test_bind_error()
     fix.req.add(protocol::bind{}).add(protocol::close{}).add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -316,9 +290,9 @@ void test_execute()
     fix.req.add(protocol::execute{}).add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -336,7 +310,7 @@ void test_execute_no_rows()
     fix.req.add(protocol::execute{}).add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -352,9 +326,9 @@ void test_execute_portal_suspended()
     fix.req.add(protocol::execute{}).add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::portal_suspended{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::portal_suspended{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -372,7 +346,7 @@ void test_execute_empty()
     fix.req.add(protocol::execute{}).add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::empty_query_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::empty_query_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -388,7 +362,7 @@ void test_execute_error()
     fix.req.add(protocol::execute{}).add(protocol::execute{}).add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -405,7 +379,7 @@ void test_describe_portal()
     fix.req.add_describe_portal("abc");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -422,7 +396,7 @@ void test_describe_portal_no_data()
     fix.req.add_describe_portal("abc");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::no_data{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::no_data{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -439,7 +413,7 @@ void test_describe_portal_error()
     fix.req.add_describe_portal("abc").add_describe_portal("def").add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -456,7 +430,7 @@ void test_close()
     fix.req.add_close_statement("abc");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::close_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::close_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -473,7 +447,7 @@ void test_close_error()
     fix.req.add_close_statement("abc").add_close_statement("def").add(protocol::sync{});
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -491,11 +465,11 @@ void test_extended_query()
     fix.req.add_query("SELECT 1");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::bind_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::bind_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -515,10 +489,10 @@ void test_async()
     fix.req.add_prepare("SELECT 1", "mystmt");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::notice_response{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::notification_response{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::parameter_status{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::notice_response{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::notification_response{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::parameter_status{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -536,15 +510,15 @@ void test_several_syncs()
     fix.req.add_describe_portal("def");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::close_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::bind_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::close_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::bind_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::data_row{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::command_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages
@@ -568,12 +542,12 @@ void test_error_recovery()
     fix.req.add_describe_portal("def");
 
     // Run the FSM
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::close_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), result_type::read);
-    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), result_type::read);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::close_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::parse_complete{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::row_description{}), needs_more);
     BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
 
     // Check handler messages

--- a/test/unit/protocol/test_read_response_fsm.cpp
+++ b/test/unit/protocol/test_read_response_fsm.cpp
@@ -561,6 +561,22 @@ void test_error_recovery()
     });
 }
 
+// If the sync is the last message, we handle it correctly
+void test_error_recovery_sync_last()
+{
+    fixture fix;
+    fix.req.add_close_statement("abc");
+
+    // Run the FSM
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::error_response{}), needs_more);
+    BOOST_TEST_EQ(fix.fsm.resume(protocol::ready_for_query{}), error_code());
+
+    // Check handler messages
+    fix.check({
+        {response_msg_type::error_response, 0u},
+    });
+}
+
 // TODO: test combining simple queries and extended queries
 // TODO: test flush
 
@@ -599,6 +615,7 @@ int main()
     test_async();
     test_several_syncs();
     test_error_recovery();
+    test_error_recovery_sync_last();
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Moves read_response_fsm private function declarations into the TU