### PR TITLE
Adds conclusions on benchmarks run with an AWS-hosted server 

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -19,11 +19,12 @@ For the server, I've got two setups:
 - One running in localhost, using Docker (`postgres:17.4` image).
   This setup represents use cases where the network latency is small
   (e.g. where both client and server run in the same machine or
-  availability zone).
+  availability zone). Caveat: client and server run in the same
+  machine and may influence each other.
 - One running in AWS, on a `t3.micro` EC2 instance with an Ubuntu 26.04 image.
   It uses the system's Postgres installation (v18.6).
   This setup represents use cases where network latency is large.
-  A full network round-trip here takes around 100ms.
+  A full network round-trip here takes around 100ms (observed with Wireshark).
 
 ## Are multiplexed connections worth it?
 
@@ -45,8 +46,9 @@ Doing this measures connection utilization (i.e. given a fixed number
 of connections, which case uses them more effectively?). This is
 important because Postgres is one process per connection, so the max
 number of connections is limited (usually `max_connections=100`).
-Intuitively, multiplexed connections should be faster because they are
-full-duplex, while dedicated connections are half-duplex.
+Intuitively, multiplexed connections should be faster because they
+pipeline concurrent requests, while dedicated connections keep
+only one connection in-flight at any given time.
 
 We measure latency, as seen by an individual session, and throughput,
 as queries completed per unit of time.
@@ -54,15 +56,20 @@ as queries completed per unit of time.
 **Conclusions**: multiplexed is faster. The larger the network latency,
 the more significant the improvement.
 
-- For the localhost server, the multiplexed connection is around 20% faster.
+- For the localhost server, the multiplexed connection has around 20% more throughput.
   Wireshark reveals almost no coalescing of writes into fewer TCP segments.
-  Speed likely comes from being full-duplex, rather than from write coalescing.
-- For the AWS server, the multiplexed connection is 80x faster.
-  We can see much more write coalescing here.
+  Speed likely comes from pipelining, rather than from write coalescing.
+- For the AWS server, the multiplexed connection has 75x more throughput,
+  with much more write coalescing than in the localhost case.
+  Since we're running 100 sessions in parallel, this number indicates
+  that we're pipelining as expected.
 
 Future work:
 
 - We need to open more than one multiplexed connection to scale effectively,
   especially if the network latency is small. Boost.Redis' recommendation
   of one multiplexed connection per application does not transfer to us.
+  This is because each Postgres connection is handled by one process
+  using sync network calls, where Redis uses a single thread for all connections
+  and non-blocking calls.
 - We should measure whether coalescing writes is really worth the complexity.

--- a/bench/README.md
+++ b/bench/README.md
@@ -7,19 +7,20 @@ Frequently, I've found benchmarks that output a bunch of numbers
 that look cool but end up translating into little useful information.
 For nativepg, I'm trying an **A/B approach**. Every benchmark
 should try to answer a particular question. It should contain
-two cases, and potentially reach to a conclusion.
+two cases, and potentially reach a conclusion.
 
 The conclusions here have been extracted by running the benchmarks
-on a i7-10510U 1.80GHz CPU with 4 cores/8 threads, under Ubuntu 24.04
-and clang-20 built with CMake 4.2.1 using the Release configuration.
+on an i7-10510U 1.80GHz CPU with 4 cores/8 threads, under Ubuntu 24.04,
+built with clang-20 and CMake 4.2.1 using the Release configuration.
 All benchmarks use plaintext TCP.
 
 For the server, I've got two setups:
 
 - One running in localhost, using Docker (`postgres:17.4` image).
   This setup represents use cases where the network latency is small
-  (e.g. where both client and server run in the same cloud/machine).
-- One running in AWS, on a `t3.micro` server with a Ubuntu 26.04 image.
+  (e.g. where both client and server run in the same machine or
+  availability zone).
+- One running in AWS, on a `t3.micro` EC2 instance with an Ubuntu 26.04 image.
   It uses the system's Postgres installation (v18.6).
   This setup represents use cases where network latency is large.
   A full network round-trip here takes around 100ms.
@@ -50,19 +51,18 @@ full-duplex, while dedicated connections are half-duplex.
 We measure latency, as seen by an individual session, and throughput,
 as queries completed per unit of time.
 
-**Conclusions**: multiplexed is faster. The bigger the network latency,
-the more significant the improvements are.
+**Conclusions**: multiplexed is faster. The larger the network latency,
+the more significant the improvement.
 
 - For the localhost server, the multiplexed connection is around 20% faster.
-  Wireshark reveals almost no coalescing of write packets.
-  Speed likely comes from being full-duplex, rather than write packet coalescing.
-- For the AWS server, the multiplexed version is x80 times faster.
-  We can see much more write packet coalescing here.
+  Wireshark reveals almost no coalescing of writes into fewer TCP segments.
+  Speed likely comes from being full-duplex, rather than from write coalescing.
+- For the AWS server, the multiplexed connection is 80x faster.
+  We can see much more write coalescing here.
 
-Future lines:
+Future work:
 
 - We need to open more than one multiplexed connection to scale effectively,
-  especially if the network latency is small. Boost.Redis' single
-  multiplexed connection per application recommendation
-  does not work for us.
+  especially if the network latency is small. Boost.Redis' recommendation
+  of one multiplexed connection per application does not transfer to us.
 - We should measure whether coalescing writes is really worth the complexity.

--- a/bench/README.md
+++ b/bench/README.md
@@ -12,10 +12,17 @@ two cases, and potentially reach to a conclusion.
 The conclusions here have been extracted by running the benchmarks
 on a i7-10510U 1.80GHz CPU with 4 cores/8 threads, under Ubuntu 24.04
 and clang-20 built with CMake 4.2.1 using the Release configuration.
+All benchmarks use plaintext TCP.
 
-The server runs in localhost, using Docker (`postgres:17.4`).
-Ideally, both pieces of code should run in independent machines
-to reduce mutual influence, but that's a task for the future.
+For the server, I've got two setups:
+
+- One running in localhost, using Docker (`postgres:17.4` image).
+  This setup represents use cases where the network latency is small
+  (e.g. where both client and server run in the same cloud/machine).
+- One running in AWS, on a `t3.micro` server with a Ubuntu 26.04 image.
+  It uses the system's Postgres installation (v18.6).
+  This setup represents use cases where network latency is large.
+  A full network round-trip here takes around 100ms.
 
 ## Are multiplexed connections worth it?
 
@@ -43,11 +50,19 @@ full-duplex, while dedicated connections are half-duplex.
 We measure latency, as seen by an individual session, and throughput,
 as queries completed per unit of time.
 
-**Conclusions**: multiplexed is faster, but not as faster as I thought
-it would be (around 20% faster). Wireshark reveals no write multiplexing
-most of the time, probably due to the speculative write architecture
-that Corosio implements. Speed likely comes from being full-duplex,
-rather than write multiplexing.
+**Conclusions**: multiplexed is faster. The bigger the network latency,
+the more significant the improvements are.
 
-- We need to open more than one multiplexed connection to scale effectively.
-- We may be able to drop write multiplexing altogether.
+- For the localhost server, the multiplexed connection is around 20% faster.
+  Wireshark reveals almost no coalescing of write packets.
+  Speed likely comes from being full-duplex, rather than write packet coalescing.
+- For the AWS server, the multiplexed version is x80 times faster.
+  We can see much more write packet coalescing here.
+
+Future lines:
+
+- We need to open more than one multiplexed connection to scale effectively,
+  especially if the network latency is small. Boost.Redis' single
+  multiplexed connection per application recommendation
+  does not work for us.
+- We should measure whether coalescing writes is really worth the complexity.

--- a/bench/multiplexed_vs_dedicated.cpp
+++ b/bench/multiplexed_vs_dedicated.cpp
@@ -67,16 +67,6 @@ constexpr std::string_view query = "SELECT first_name FROM employee WHERE id = $
 constexpr int nqueries = 1000;
 constexpr int nsess = 100;
 
-connect_params make_connect_params()
-{
-    return {
-        .hostname = "localhost",
-        .username = "postgres",
-        .password = "secret",
-        .database = "postgres",
-    };
-}
-
 // The benchmark has nothing meaningful to report if any operation fails,
 // so bail out as soon as one does.
 [[noreturn]] void die(
@@ -172,13 +162,13 @@ void print_results(const char* name, double elapsed_secs, const stats& latency)
               << "  stddev:            " << latency.stddev() << '\n';
 }
 
-capy::task<> run_dedicated()
+capy::task<> run_dedicated(const connect_params& params)
 {
     // Setup
     dedicated_state st{co_await capy::this_coro::executor};
 
     // Establishing the connection is not part of the measurement
-    if (auto [ec] = co_await st.conn.connect(make_connect_params()); ec)
+    if (auto [ec] = co_await st.conn.connect(params); ec)
         die("connect", ec);
 
     // Discard one query, so that first-query costs don't land in the
@@ -260,11 +250,11 @@ capy::io_task<> multiplexed_bench(multiplexed_state& st)
     co_return {};
 }
 
-capy::task<> run_multiplexed()
+capy::task<> run_multiplexed(const connect_params& params)
 {
     // Setup
     multiplexed_state st{co_await capy::this_coro::executor};
-    multiplexed_config cfg{.transport = make_connect_params()};
+    multiplexed_config cfg{.transport = params};
 
     // run() only returns on error, so race it against the benchmark: once the
     // benchmark wins, when_any stop-requests run() and waits for it to unwind.
@@ -273,16 +263,30 @@ capy::task<> run_multiplexed()
         die("multiplexed", std::get<0>(res));
 }
 
-capy::task<> co_main()
+// params must outlive this coroutine
+capy::task<> co_main(const connect_params& params)
 {
-    co_await run_dedicated();
-    co_await run_multiplexed();
+    co_await run_dedicated(params);
+    co_await run_multiplexed(params);
 }
 
 }  // namespace
 
-int main()
+int main(int argc, char** argv)
 {
+    // All arguments are positional and required
+    if (argc != 5)
+    {
+        std::cerr << "Usage: " << argv[0] << " <hostname> <username> <password> <database>\n";
+        return 1;
+    }
+    const connect_params params{
+        .hostname = argv[1],
+        .username = argv[2],
+        .password = argv[3],
+        .database = argv[4],
+    };
+
     // The I/O context, required for all I/O operations
     corosio::io_context ctx;
 
@@ -302,7 +306,7 @@ int main()
             }
             exit(1);
         }
-    )(co_main());
+    )(co_main(params));
 
     // Executes all pending work, including the main coroutine
     ctx.run();


### PR DESCRIPTION
Makes the benchmark configurable with hostname, credentials and database