### PR TITLE
Adds co_connection::shutdown()

### DIFF
--- a/example/co_connection.cpp
+++ b/example/co_connection.cpp
@@ -81,6 +81,15 @@ static capy::task<> co_main()
 
     for (const auto& r : vec)
         std::cout << "Got row: " << r.f1 << ", " << r.f3 << std::endl;
+
+    // Orderly close the connection.
+    // May report a failure if the server is gone.
+    // The connection is closed anyway in that case.
+    if (auto [shutdown_ec] = co_await conn.shutdown(); shutdown_ec)
+    {
+        print_err("Error during shutdown", shutdown_ec, {});
+        co_return;
+    }
 }
 
 int main()

--- a/example/copy_out.cpp
+++ b/example/copy_out.cpp
@@ -92,6 +92,15 @@ static capy::task<> co_main()
             }
         }
     }
+
+    // Orderly close the connection.
+    // May report a failure if the server is gone.
+    // The connection is closed anyway in that case.
+    if (auto [shutdown_ec] = co_await conn.shutdown(); shutdown_ec)
+    {
+        print_err("Error during shutdown", shutdown_ec, {});
+        co_return;
+    }
 }
 
 int main()

--- a/example/execute_max_rows.cpp
+++ b/example/execute_max_rows.cpp
@@ -121,6 +121,15 @@ static capy::task<> co_main()
         print_err("Error during cleanup", ec, diag);
         co_return;
     }
+
+    // Orderly close the connection.
+    // May report a failure if the server is gone.
+    // The connection is closed anyway in that case.
+    if (auto [shutdown_ec] = co_await conn.shutdown(); shutdown_ec)
+    {
+        print_err("Error during shutdown", shutdown_ec, {});
+        co_return;
+    }
 }
 
 int main()

--- a/example/prepared_statements.cpp
+++ b/example/prepared_statements.cpp
@@ -105,6 +105,15 @@ static capy::task<> co_main()
         print_err("Error closing", ec, diag);
         co_return;
     }
+
+    // Orderly close the connection.
+    // May report a failure if the server is gone.
+    // The connection is closed anyway in that case.
+    if (auto [shutdown_ec] = co_await conn.shutdown(); shutdown_ec)
+    {
+        print_err("Error during shutdown", shutdown_ec, {});
+        co_return;
+    }
 }
 
 int main()

--- a/example/resultsets.cpp
+++ b/example/resultsets.cpp
@@ -92,6 +92,15 @@ static capy::task<> co_main()
             std::cout << info.command_complete_tag << '\n';
         std::cout << "\n-------------------------\n";
     }
+
+    // Orderly close the connection.
+    // May report a failure if the server is gone.
+    // The connection is closed anyway in that case.
+    if (auto [shutdown_ec] = co_await conn.shutdown(); shutdown_ec)
+    {
+        print_err("Error during shutdown", shutdown_ec, {});
+        co_return;
+    }
 }
 
 int main()

--- a/example/update_affected_rows.cpp
+++ b/example/update_affected_rows.cpp
@@ -63,6 +63,15 @@ static capy::task<> co_main()
     }
 
     std::cout << "Affected: " << info.affected_rows.value_or(0u) << " rows\n";
+
+    // Orderly close the connection.
+    // May report a failure if the server is gone.
+    // The connection is closed anyway in that case.
+    if (auto [shutdown_ec] = co_await conn.shutdown(); shutdown_ec)
+    {
+        print_err("Error during shutdown", shutdown_ec, {});
+        co_return;
+    }
 }
 
 int main()

--- a/include/nativepg/co_connection.hpp
+++ b/include/nativepg/co_connection.hpp
@@ -105,6 +105,9 @@ public:
 
     boost::capy::io_task<> connect(connect_params params, diagnostics* diag = nullptr);
 
+    // Closes the connection (PQfinish)
+    boost::capy::io_task<> shutdown();
+
     boost::capy::io_task<> exec(
         const request& req,
         response_handler_ref handler,

--- a/include/nativepg/protocol/connection_state.hpp
+++ b/include/nativepg/protocol/connection_state.hpp
@@ -32,6 +32,15 @@ struct connection_state
 
     // TODO: this is safe for now, but is there any case where it may not be?
     diagnostics shared_diag;
+
+    void reset()
+    {
+        write_buffer.clear();
+        read_buffer.reset();
+        backend_process_id = {};
+        backend_secret_key = {};
+        // shared_diag are transient by nature
+    }
 };
 
 }  // namespace nativepg::protocol

--- a/src/co_connection.cpp
+++ b/src/co_connection.cpp
@@ -28,6 +28,7 @@
 #include "nativepg/protocol/detail/exec_fsm.hpp"
 #include "nativepg/protocol/detail/exec_some_fsm.hpp"
 #include "nativepg/protocol/parse_message.hpp"
+#include "nativepg/protocol/terminate.hpp"
 #include "nativepg/request.hpp"
 #include "nativepg/responses/response_handler.hpp"
 
@@ -55,6 +56,25 @@ struct co_connection::impl
 
         auto [ec2, ep] = co_await boost::corosio::connect(sock, endpoints);
         co_return {ec2};
+    }
+
+    capy::io_task<> shutdown()
+    {
+        // TODO: we should probably have some state checks
+        // TODO: we could really serialize to a fixed storage block, this is known size
+        // Serialize the terminate request
+        st.write_buffer.clear();
+        if (auto ec = protocol::serialize(protocol::terminate{}, st.write_buffer))
+            co_return {ec};
+
+        // Write it
+        auto [write_ec, bytes] = co_await capy::write(stream, capy::make_buffer(st.write_buffer));
+
+        // Close the underlying transport anyway
+        sock.shutdown(corosio::tcp_socket::shutdown_type::shutdown_both);
+        sock.close();
+
+        co_return {write_ec};
     }
 
     void setup_request(const request& req, response_handler_ref handler)
@@ -198,6 +218,8 @@ capy::io_task<> co_connection::connect(connect_params params, diagnostics* diag)
         }
     }
 }
+
+capy::io_task<> co_connection::shutdown() { return impl_->shutdown(); }
 
 capy::io_task<> co_connection::exec(const request& req, response_handler_ref handler, diagnostics* diag)
 {

--- a/src/co_connection.cpp
+++ b/src/co_connection.cpp
@@ -62,6 +62,8 @@ struct co_connection::impl
     {
         // TODO: we should probably have some state checks
         // TODO: we could really serialize to a fixed storage block, this is known size
+        // TODO: an error here shouldn't prevent the function from closing the transport
+        //       (the error should not happen, to begin with)
         // Serialize the terminate request
         st.write_buffer.clear();
         if (auto ec = protocol::serialize(protocol::terminate{}, st.write_buffer))
@@ -70,8 +72,12 @@ struct co_connection::impl
         // Write it
         auto [write_ec, bytes] = co_await capy::write(stream, capy::make_buffer(st.write_buffer));
 
-        // Close the underlying transport anyway
-        sock.shutdown(corosio::tcp_socket::shutdown_type::shutdown_both);
+        // Close the underlying transport anyway.
+        // No tcp_socket::shutdown() here to match what libpq does.
+        // At least on Linux, it does nothing:
+        // both close() and shutdown(SHUT_RDWR) will send a RST if there is pending
+        // data in the read buffer (e.g. a pending NotificationResponse),
+        // and a FIN otherwise. Should't be a big deal.
         sock.close();
 
         co_return {write_ec};

--- a/src/startup_fsm.cpp
+++ b/src/startup_fsm.cpp
@@ -88,8 +88,10 @@ startup_fsm_impl::result startup_fsm_impl::resume(
     {
         NATIVEPG_CORO_INITIAL
 
+        // Reset any pending state
+        st.reset();
+
         // Compose the startup message
-        st.write_buffer.clear();
         if (auto ec = serialize(make_startup_message(*params_), st.write_buffer))
         {
             return ec;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,4 +70,5 @@ nativepg_add_test(unit/types             test_json)
 
 if (NATIVEPG_COROSIO_API)
     nativepg_add_test(integration            test_co_connection  nativepg_test_utils_corosio)
+    nativepg_add_test(integration            test_co_connection_shutdown  nativepg_test_utils_corosio)
 endif()

--- a/test/integration/test_co_connection_shutdown.cpp
+++ b/test/integration/test_co_connection_shutdown.cpp
@@ -38,7 +38,7 @@ capy::task<> test_shutdown()
     // Sanity check: the connection works before shutting it down
     request req;
     req.add_simple_query("SELECT 1");
-    if (!check_success(co_await conn.exec(req, check_execute(), &diag), diag))
+    if (!check_success(co_await conn.exec(req, check(), &diag), diag))
         co_return;
 
     // Shut the connection down. This should succeed
@@ -46,39 +46,13 @@ capy::task<> test_shutdown()
     BOOST_TEST_EQ(shutdown_ec, std::error_code());
 
     // exec no longer works
-    auto [exec_ec] = co_await conn.exec(req, check_execute());
+    auto [exec_ec] = co_await conn.exec(req, check());
     BOOST_TEST_NE(exec_ec, std::error_code());
-}
 
-// Regression test: after shutdown, the connection can be re-opened,
-// even if there were unread bytes in the network buffer.
-capy::task<> test_shutdown_reopen_pending_bytes()
-{
-    // Setup
-    diagnostics diag;
-    co_connection conn{co_await capy::this_coro::executor};
+    // The connection can be re-opened
     if (!check_success(co_await conn.connect(default_connect_params(), &diag), diag))
         co_return;
-
-    // Produce a NotificiationResponse that won't be read yet.
-    request req;
-    req.add_simple_query("LISTEN my_channel");
-    req.add_simple_query("NOTIFY my_channel");
-    if (!check_success(co_await conn.exec(req, check_execute(), &diag), diag))
-        co_return;
-
-    // Shut the connection down
-    auto [shutdown_ec] = co_await conn.shutdown();
-    BOOST_TEST_EQ(shutdown_ec, std::error_code());
-
-    // We can re-establish the connection
-    if (!check_success(co_await conn.connect(default_connect_params(), &diag), diag))
-        co_return;
-
-    // The connection works
-    request req_select;
-    req_select.add_simple_query("SELECT 1");
-    if (!check_success(co_await conn.exec(req_select, check_execute(), &diag), diag))
+    if (!check_success(co_await conn.exec(req, check(), &diag), diag))
         co_return;
 }
 
@@ -87,7 +61,6 @@ capy::task<> test_shutdown_reopen_pending_bytes()
 int main()
 {
     run_coroutine_test(test_shutdown());
-    run_coroutine_test(test_shutdown_reopen_pending_bytes());
 
     return boost::report_errors();
 }

--- a/test/integration/test_co_connection_shutdown.cpp
+++ b/test/integration/test_co_connection_shutdown.cpp
@@ -50,11 +50,44 @@ capy::task<> test_shutdown()
     BOOST_TEST_NE(exec_ec, std::error_code());
 }
 
+// Regression test: after shutdown, the connection can be re-opened,
+// even if there were unread bytes in the network buffer.
+capy::task<> test_shutdown_reopen_pending_bytes()
+{
+    // Setup
+    diagnostics diag;
+    co_connection conn{co_await capy::this_coro::executor};
+    if (!check_success(co_await conn.connect(default_connect_params(), &diag), diag))
+        co_return;
+
+    // Produce a NotificiationResponse that won't be read yet.
+    request req;
+    req.add_simple_query("LISTEN my_channel");
+    req.add_simple_query("NOTIFY my_channel");
+    if (!check_success(co_await conn.exec(req, check_execute(), &diag), diag))
+        co_return;
+
+    // Shut the connection down
+    auto [shutdown_ec] = co_await conn.shutdown();
+    BOOST_TEST_EQ(shutdown_ec, std::error_code());
+
+    // We can re-establish the connection
+    if (!check_success(co_await conn.connect(default_connect_params(), &diag), diag))
+        co_return;
+
+    // The connection works
+    request req_select;
+    req_select.add_simple_query("SELECT 1");
+    if (!check_success(co_await conn.exec(req_select, check_execute(), &diag), diag))
+        co_return;
+}
+
 }  // namespace
 
 int main()
 {
     run_coroutine_test(test_shutdown());
+    run_coroutine_test(test_shutdown_reopen_pending_bytes());
 
     return boost::report_errors();
 }

--- a/test/integration/test_co_connection_shutdown.cpp
+++ b/test/integration/test_co_connection_shutdown.cpp
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/capy/ex/this_coro.hpp>
+#include <boost/capy/io_result.hpp>
+#include <boost/capy/task.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#include <system_error>
+
+#include "nativepg/co_connection.hpp"
+#include "nativepg/extended_error.hpp"
+#include "nativepg/request.hpp"
+#include "nativepg/responses/check.hpp"
+#include "test_utils/ci_server.hpp"
+#include "test_utils/corosio_utils.hpp"
+#include "test_utils/printing.hpp"
+
+namespace capy = boost::capy;
+using namespace nativepg;
+using namespace nativepg::test;
+
+namespace {
+
+// After shutdown, the connection is unusable: exec fails and performs no I/O
+capy::task<> test_shutdown()
+{
+    // Setup
+    diagnostics diag;
+    co_connection conn{co_await capy::this_coro::executor};
+    if (!check_success(co_await conn.connect(default_connect_params(), &diag), diag))
+        co_return;
+
+    // Sanity check: the connection works before shutting it down
+    request req;
+    req.add_simple_query("SELECT 1");
+    if (!check_success(co_await conn.exec(req, check_execute(), &diag), diag))
+        co_return;
+
+    // Shut the connection down. This should succeed
+    auto [shutdown_ec] = co_await conn.shutdown();
+    BOOST_TEST_EQ(shutdown_ec, std::error_code());
+
+    // exec no longer works
+    auto [exec_ec] = co_await conn.exec(req, check_execute());
+    BOOST_TEST_NE(exec_ec, std::error_code());
+}
+
+}  // namespace
+
+int main()
+{
+    run_coroutine_test(test_shutdown());
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Properly resets connection state during startup. This prevents potential connection establishment failures if unread data from previous sessions was kept in the read buffer
Adds calls to shutdown() in all examples that use co_connection